### PR TITLE
Drop Elixir 1.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: elixir
 elixir:
   - 1.3.4
-  - 1.4.0-rc.1
+  - 1.4.5
+  - 1.5.1
 otp_release:
   - 19.1
+  - 20.0
+matrix:
+  exclude:
+    - elixir: 1.3.4
+      otp_release: 20.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: elixir
 elixir:
-  - 1.3.4
   - 1.4.5
   - 1.5.1
 otp_release:
   - 19.1
   - 20.0
-matrix:
-  exclude:
-    - elixir: 1.3.4
-      otp_release: 20.0

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Kazan.Mixfile do
   def project do
     [app: :kazan,
      version: "0.3.0",
-     elixir: "~> 1.3",
+     elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),


### PR DESCRIPTION
Elixir 1.4 has been out for ages, and we're about to make a large breaking change with support for Kubernetes 1.7, so this seems as good a time as any.

Also updated the versions we run against on travis.