### PR TITLE
Add support for `insecure-skip-tls-verify`.

### DIFF
--- a/lib/kazan/client.ex
+++ b/lib/kazan/client.ex
@@ -93,10 +93,15 @@ defmodule Kazan.Client do
   @spec ssl_options(Server.t) :: Keyword.t
   defp ssl_options(server) do
     auth_options = ssl_auth_options(server.auth)
-    case server.ca_cert do
-      nil -> auth_options
-      cert -> auth_options ++ [cacerts: [cert]]
+    verify_options = case server.insecure_skip_tls_verify do
+      true -> [verify: :verify_none]
+      _ -> []
     end
+    ca_options = case server.ca_cert do
+      nil -> []
+      cert -> [cacerts: [cert]]
+    end
+    auth_options ++ verify_options ++ ca_options
   end
 
   defp ssl_auth_options(%Server.CertificateAuth{certificate: cert, key: key}) do

--- a/lib/kazan/server.ex
+++ b/lib/kazan/server.ex
@@ -5,10 +5,16 @@ defmodule Kazan.Server do
 
   @type auth_t :: nil | Kazan.Server.CertificateAuth.t
 
-  defstruct [url: nil, ca_cert: nil, auth: nil]
+  defstruct [
+    url: nil,
+    ca_cert: nil,
+    auth: nil,
+    insecure_skip_tls_verify: nil
+  ]
 
   @type t :: %{
     url: String.t,
+    insecure_skip_tls_verify: Boolean.t,
     ca_cert: String.t | nil,
     auth: auth_t
   }
@@ -44,7 +50,8 @@ defmodule Kazan.Server do
     %__MODULE__{
       url: cluster["server"],
       ca_cert: get_cert(cluster, basepath),
-      auth: auth_from_user(user, basepath)
+      auth: auth_from_user(user, basepath),
+      insecure_skip_tls_verify: cluster["insecure-skip-tls-verify"]
     }
   end
 
@@ -104,7 +111,7 @@ defmodule Kazan.Server do
     case Base.decode64(encoded_cert) do
       {:ok, cert_data} ->
           :public_key.pem_decode(cert_data)
-            |> Enum.find_value(fn 
+            |> Enum.find_value(fn
               {:Certificate, data, _} -> data
               _ -> nil
           end)


### PR DESCRIPTION
This disables TLS verification - useful during development if using
unsigned certificates.