### PR TITLE
Add Elixir 1.6.0 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: elixir
 elixir:
   - 1.4.5
-  - 1.5.1
+  - 1.5.3
+  - 1.6.0
 otp_release:
-  - 19.1
-  - 20.0
+  - 19.2
+  - 20.2

--- a/lib/kazan/codegen/models.ex
+++ b/lib/kazan/codegen/models.ex
@@ -52,12 +52,7 @@ defmodule Kazan.Codegen.Models do
       model_name
       |> strip_module_name_prefixes
       |> String.split(".")
-      |> Enum.map(fn (str) ->
-        # We can't just use String.titlecase because that
-        # lowercases all the following words...
-        {first, rest} = String.Casing.titlecase_once(str)
-        first <> rest
-      end)
+      |> Enum.map(&titlecase_once/1)
       |> Enum.join(".")
 
     if Keyword.get(opts, :unsafe, false) do
@@ -182,5 +177,11 @@ defmodule Kazan.Codegen.Models do
       "io.k8s.kube-aggregator." <> rest ->
         "KubeAggregator" <> rest
     end
+  end
+
+  # Uppercases the first character of str
+  defp titlecase_once(str) do
+    first_letter = String.first(str)
+    String.replace_prefix(str, first_letter, String.upcase(first_letter))
   end
 end


### PR DESCRIPTION
Also update some old Elixir versions & OTP versions.

Had to stop using String.Casing.titlecase_once as part of this, as it's
API has changed.  Just doing the same thing manually now.