### PR TITLE
Reorganise API & Model modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@ all APIs might be changed.
 
 ### Breaking Changes
 
-- The k8s 1.8 specs changed the OAI names of most of the models in the API. As a
-  result, most of the models under `Kazan.Models` have changed location.
-- Most APIs have changed modules slightly to have a dot between the group name
-  and the version. For example: `Kazan.Apis.CoreV1` is now `Kazan.Apis.Core.V1`.
+- The module names of most APIs & many models has been changed.
+  - APIs module names have changed slightly to have a dot between the group name
+    and the version. For example: `Kazan.Apis.CoreV1` is now `Kazan.Apis.Core.V1`.
+  - Models that are associated with an API now live inside that APIs module,
+    rather than under `Kazan.Models`.  For example `Kazan.Models.Api.V1.Container`
+    now lives under `Kazan.Apis.Core.V1.Container`
+  - Models that are not associated with specific APIs (e.g. Apimachinery models)
+    still live under `Kazan.Models`.
+  - Some underlying changes in the names of models in the k8s spec may also have
+    caused things to move around.
 
 ### New Features
 
@@ -34,6 +40,12 @@ all APIs might be changed.
   `x-kubernetes-group-version-kind` field in the OAI spec. If we're attempting
   to deserialize a model that doesn't hae this present in the spec, things may
   go wrong.
+- Improved the documentation of API modules.
+
+### Deprecations
+
+- `Kazan.Models.oai_name_to_module` still supports the older OAI name format,
+  but this is now deprecated and will be removed in a future version.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ all APIs might be changed.
 
 - The k8s 1.8 specs changed the OAI names of most of the models in the API. As a
   result, most of the models under `Kazan.Models` have changed location.
+- Most APIs have changed modules slightly to have a dot between the group name
+  and the version. For example: `Kazan.Apis.CoreV1` is now `Kazan.Apis.Core.V1`.
 
 ### New Features
 

--- a/README.md
+++ b/README.md
@@ -113,12 +113,10 @@ Alternatively, you might want to specify the server to send the request to:
 ```elixir
 server = Kazan.Server.in_cluster
 
-Kazan.Apis.CoreV1.list_pod_for_all_namespaces!
+Kazan.Apis.Core.V1.list_pod_for_all_namespaces!
 |> Kazan.Client.run!(server: server)
-# %Kazan.Models.V1.PodList{...}
+# %Kazan.Apis.Core.V1.PodList{...}
 ```
 
 More details on building requests can be found in the documentation for
 `Kazan.Apis`.
-
-All the models reutrned by the application can be found under `Kazan.Models`

--- a/lib/kazan.ex
+++ b/lib/kazan.ex
@@ -4,9 +4,17 @@ defmodule Kazan do
 
   ### Module Overview
 
-  - `Kazan.Models` contains structs that can be sent and received by kube.
-  - `Kazan.Apis` contains modules that contain functions for building requests
-    to send to the kube API.
+  - `Kazan.Apis` contains modules for building requests to send to the kube API.
+    - `Kazan.Apis.*` modules represent one of the "groups" of API functionality
+      exposed by k8s. The root of these modules usually contain functions for
+      checking the capabilities of a k8s server.
+    - `Kazan.Apis.*.*` modules represent a particular version of an API. These
+      modules expose functions that can be called to build requests to send to
+      the k8s API.
+    - `Kazan.Apis.*.*.*` modules contain some struct definitions that can be
+      used to build requests and can be received in responses from the API.
+  - `Kazan.Models` contains other structs that can be sent and received by k8s,
+    but are not specifically tied to any one API group.
   - `Kazan.Client` is responsible for actually sending those requests.
 
   See the [README](readme.html) for example usage.

--- a/lib/kazan/apis.ex
+++ b/lib/kazan/apis.ex
@@ -5,14 +5,18 @@ defmodule Kazan.Apis do
   This module contains many sub-modules, one corresponding to each API group
   present in the OpenAPI specification for Kubernetes.
 
-  Each of these modules will contain functions that can be called to generate
-  Kazan.Request structures that can be fed into Kazan.Client.
+  Each of these modules will contain submodules that repreesent the different
+  versions of the API group. Within those submodules will be functions that can
+  be called to generate `Kazan.Request` structures that can be fed into
+  `Kazan.Client`. The version submodules will also contain any structs that can
+  be sent & received by that particular version of the API group.
 
-  The functions arguments are generated so that any HTTP body parameter is
-  first, followed by any path parameters in path order, followed by any required
-  query parameters. Optional query parameters should go in the optional final
-  keyword argument.
+  Each request functions arguments are generated so that any HTTP body parameter
+  is first, followed by any path parameters in path order, followed by any
+  required query parameters. Optional query parameters should go in the optional
+  final keyword argument.
   """
+
   require Kazan.Codegen.Apis
   alias Kazan.Codegen
 
@@ -36,8 +40,8 @@ defmodule Kazan.Apis do
              Atom.to_string(operation.function_name) <> "!"
            )
 
-           [{operation.api_name, operation.function_name},
-            {operation.api_name, bang_function_name}]
+           [{operation.api_module, operation.function_name},
+            {operation.api_module, bang_function_name}]
        end
   end
 end

--- a/lib/kazan/codegen/apis.ex
+++ b/lib/kazan/codegen/apis.ex
@@ -66,12 +66,19 @@ defmodule Kazan.Codegen.Apis do
   """
   @spec api_name(String.t, Keyword.t) :: atom
   def api_name(operation_tag, opts \\ []) do
-    api_name = Macro.camelize(operation_tag)
+    components =
+      case String.split(operation_tag, "_") do
+        [group, version] ->
+          [Kazan.Apis, String.capitalize(group), String.capitalize(version)]
+        [group] ->
+          [Kazan.Apis, String.capitalize(group)]
+      end
+
     if Keyword.get(opts, :unsafe, false) do
-      Module.concat(Kazan.Apis, api_name)
+      Module.concat(components)
     else
       try do
-        Module.safe_concat(Kazan.Apis, api_name)
+        Module.safe_concat(components)
       rescue ArgumentError ->
           nil
       end

--- a/lib/kazan/codegen/apis/api_id.ex
+++ b/lib/kazan/codegen/apis/api_id.ex
@@ -1,0 +1,25 @@
+defmodule Kazan.Codegen.Apis.ApiId do
+  @moduledoc false
+  # Stores the kind, version & group of a kubernetes resource.
+
+  @enforce_keys [:group, :version]
+  defstruct [:group, :version]
+
+  @type t :: %{
+    group: String.t,
+    version: String.t | nil
+  }
+
+  @spec from_oai_tag(String.t) :: t
+  def from_oai_tag(operation_tag) do
+    {group, version} =
+      case String.split(operation_tag, "_") do
+        [group, version] ->
+          {String.capitalize(group), String.capitalize(version)}
+        [group] ->
+          {String.capitalize(group), nil}
+      end
+
+    %__MODULE__{group: group, version: version}
+  end
+end

--- a/lib/kazan/codegen/apis/operation.ex
+++ b/lib/kazan/codegen/apis/operation.ex
@@ -1,18 +1,19 @@
 defmodule Kazan.Codegen.Apis.Operation do
   @moduledoc false
 
-  alias Kazan.Codegen.Apis.Parameter
+  alias Kazan.Codegen.Apis.{ApiId, Parameter}
   alias Kazan.Codegen
 
   defstruct [
-    :function_name, :api_name, :operation_id,
+    :function_name, :api_module, :api_id, :operation_id,
     :parameters, :response_schema, :description,
     :path
   ]
 
   @type t :: %__MODULE__{
     function_name: :atom,
-    api_name: :atom,
+    api_module: :atom,
+    api_id: ApiId.t,
     operation_id: String.t,
     parameters: list,
     response_schema: struct,
@@ -22,11 +23,14 @@ defmodule Kazan.Codegen.Apis.Operation do
 
   @spec from_oai_desc(Map.t) :: t
   def from_oai_desc(desc) do
+    api_id = ApiId.from_oai_tag(desc["tag"])
+
     %__MODULE__{
       function_name: Codegen.Apis.function_name(
         desc["operationId"], desc["tag"], unsafe: true
       ),
-      api_name: Codegen.Apis.api_name(desc["tag"]),
+      api_module: Codegen.Apis.api_module(api_id),
+      api_id: api_id,
       operation_id: desc["operationId"],
       parameters: Enum.map(desc["parameters"], &Parameter.from_oai_desc/1),
       response_schema: Codegen.Models.definition_ref_to_module_name(

--- a/lib/kazan/models.ex
+++ b/lib/kazan/models.ex
@@ -1,11 +1,12 @@
 defmodule Kazan.Models do
   @moduledoc """
-  Contains generated structs for all Kube models as defined in the OAI specs.
+  Contains structs for all k8s models that don't belong to a specific API group.
 
-  Each namespace underneath Kazan.Models represents a single struct as used by
+  Each module underneath Kazan.Models represents a single struct as used by
   the Kubernetes API.
 
-  Also contains functions for serializing & deserializing these generated structs.
+  Also contains functions for serializing & deserializing these generated
+  structs, though users should usually not need to interact with them.
   """
   require Kazan.Codegen.Models
   alias Kazan.Codegen

--- a/test/apis_test.exs
+++ b/test/apis_test.exs
@@ -4,7 +4,6 @@ defmodule KazanApiTests do
   alias Kazan.Apis.Core.V1, as: CoreV1
   alias Kazan.Apis.Extensions.V1beta1, as: ExtensionsV1beta1
   alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
-  alias Kazan.Models.Core.V1.Namespace
 
   describe "Apis.oai_id_to_functions" do
     test "it returns a list of functions for known operations" do
@@ -46,7 +45,7 @@ defmodule KazanApiTests do
 
   test "request with body params" do
     {:ok, res} = CoreV1.create_namespace(
-      %Namespace{
+      %CoreV1.Namespace{
         metadata: %ObjectMeta{
           name: "test"
         }

--- a/test/apis_test.exs
+++ b/test/apis_test.exs
@@ -1,7 +1,8 @@
 defmodule KazanApiTests do
   use ExUnit.Case
 
-  alias Kazan.Apis.{CoreV1, ExtensionsV1beta1}
+  alias Kazan.Apis.Core.V1, as: CoreV1
+  alias Kazan.Apis.Extensions.V1beta1, as: ExtensionsV1beta1
   alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
   alias Kazan.Models.Core.V1.Namespace
 

--- a/test/codegen/apis_test.exs
+++ b/test/codegen/apis_test.exs
@@ -2,15 +2,20 @@ defmodule KazanCodegenApisTest do
   use ExUnit.Case
 
   alias Kazan.Codegen.Apis
+  alias Kazan.Codegen.Apis.ApiId
 
-  describe "api_name" do
+  describe "api_module" do
     test "returns nil when unknown name in safe mode" do
-      assert Apis.api_name("nope") == nil
+      assert Apis.api_module(
+        %ApiId{group: "core", version: "whatever_i_want"}
+      ) == nil
     end
 
     test "returns a module name when in unsafe mode" do
-      mod_name = Apis.api_name("yep", unsafe: true)
-      assert mod_name == Kazan.Apis.Yep
+      mod_name = Apis.api_module(
+        %ApiId{group: "Yep", version: "Something"}, unsafe: true
+      )
+      assert mod_name == Kazan.Apis.Yep.Something
     end
   end
 end

--- a/test/codegen/models_test.exs
+++ b/test/codegen/models_test.exs
@@ -5,14 +5,19 @@ defmodule KazanCodegenModelsTest do
 
   describe "module_name" do
     test "returns nil when unknown name in safe mode" do
-      assert Models.module_name("io.k8s.kubernetes.pkg.api.nope") == nil
+      assert Models.module_name("io.k8s.api.core.v1.nope") == nil
     end
 
     test "returns a module name when in unsafe mode" do
       mod_name = Models.module_name(
-        "io.k8s.kubernetes.pkg.api.yep.something", unsafe: true
+        "io.k8s.api.core.v1.something", unsafe: true
       )
-      assert mod_name == Kazan.Models.Api.Yep.Something
+      assert mod_name == Kazan.Apis.Core.V1.Something
+    end
+
+    test "returns actual core module names" do
+      mod_name = Models.module_name("io.k8s.api.core.v1.Binding")
+      assert mod_name == Kazan.Apis.Core.V1.Binding
     end
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -4,7 +4,6 @@ defmodule KazanIntegrationTest do
   alias Kazan.Apis.Core.V1, as: CoreV1
   alias Kazan.Apis.Extensions.V1beta1, as: ExtensionsV1beta1
   alias Kazan.Apis.Rbacauthorization.V1beta1, as: RbacauthorizationV1beta1
-  alias Kazan.Models.Core.V1
   alias Kazan.Models.Apimachinery.Meta.V1.{
     ObjectMeta,
     DeleteOptions,
@@ -46,11 +45,11 @@ defmodule KazanIntegrationTest do
   test "can create, patch and delete a pod", %{server: server} do
     created_pod =
       CoreV1.create_namespaced_pod!(
-        %V1.Pod{
+        %CoreV1.Pod{
           metadata: %ObjectMeta{name: "kazan-test"},
-          spec: %V1.PodSpec{
+          spec: %CoreV1.PodSpec{
             containers: [
-              %V1.Container{
+              %CoreV1.Container{
                 args: [],
                 image: "obmarg/health-proxy",
                 name: "main-process",
@@ -69,9 +68,9 @@ defmodule KazanIntegrationTest do
     assert read_pod.spec == %{created_pod.spec | node_name: read_pod.spec.node_name}
 
     patched_pod = CoreV1.patch_namespaced_pod!(
-      %V1.Pod{
+      %CoreV1.Pod{
         metadata: %ObjectMeta{name: "kazan-test"},
-        spec: %V1.PodSpec{
+        spec: %CoreV1.PodSpec{
           active_deadline_seconds: 5
         }
       },

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,6 +1,9 @@
 defmodule KazanIntegrationTest do
   use ExUnit.Case, async: true
 
+  alias Kazan.Apis.Core.V1, as: CoreV1
+  alias Kazan.Apis.Extensions.V1beta1, as: ExtensionsV1beta1
+  alias Kazan.Apis.Rbacauthorization.V1beta1, as: RbacauthorizationV1beta1
   alias Kazan.Models.Core.V1
   alias Kazan.Models.Apimachinery.Meta.V1.{
     ObjectMeta,
@@ -21,7 +24,7 @@ defmodule KazanIntegrationTest do
 
   test "can list namespaces on an actual server", %{server: server} do
     namespace_list =
-      Kazan.Apis.CoreV1.list_namespace!
+      CoreV1.list_namespace!
       |> Kazan.Client.run!(server: server)
 
     # Check that there's a default namespace.
@@ -31,18 +34,18 @@ defmodule KazanIntegrationTest do
   end
 
   test "can list pods on an actual server", %{server: server} do
-    Kazan.Apis.CoreV1.list_namespaced_pod!(@namespace)
+    CoreV1.list_namespaced_pod!(@namespace)
     |> Kazan.Client.run!(server: server)
   end
 
   test "can list deployments on an actual server", %{server: server} do
-    Kazan.Apis.ExtensionsV1beta1.list_namespaced_deployment!(@namespace)
+    ExtensionsV1beta1.list_namespaced_deployment!(@namespace)
     |> Kazan.Client.run!(server: server)
   end
 
   test "can create, patch and delete a pod", %{server: server} do
     created_pod =
-      Kazan.Apis.CoreV1.create_namespaced_pod!(
+      CoreV1.create_namespaced_pod!(
         %V1.Pod{
           metadata: %ObjectMeta{name: "kazan-test"},
           spec: %V1.PodSpec{
@@ -60,12 +63,12 @@ defmodule KazanIntegrationTest do
       |> Kazan.Client.run!(server: server)
 
     read_pod =
-      Kazan.Apis.CoreV1.read_namespaced_pod!(@namespace, "kazan-test")
+      CoreV1.read_namespaced_pod!(@namespace, "kazan-test")
       |> Kazan.Client.run!(server: server)
 
     assert read_pod.spec == %{created_pod.spec | node_name: read_pod.spec.node_name}
 
-    patched_pod = Kazan.Apis.CoreV1.patch_namespaced_pod!(
+    patched_pod = CoreV1.patch_namespaced_pod!(
       %V1.Pod{
         metadata: %ObjectMeta{name: "kazan-test"},
         spec: %V1.PodSpec{
@@ -79,12 +82,12 @@ defmodule KazanIntegrationTest do
     assert patched_pod.spec == %{read_pod.spec | active_deadline_seconds: 5}
 
     read_pod =
-      Kazan.Apis.CoreV1.read_namespaced_pod!(@namespace, "kazan-test")
+      CoreV1.read_namespaced_pod!(@namespace, "kazan-test")
       |> Kazan.Client.run!(server: server)
 
     assert read_pod == patched_pod
 
-    Kazan.Apis.CoreV1.delete_namespaced_pod!(
+    CoreV1.delete_namespaced_pod!(
       %DeleteOptions{}, @namespace, "kazan-test"
     )
     |> Kazan.Client.run!(server: server)
@@ -92,7 +95,7 @@ defmodule KazanIntegrationTest do
 
   test "RBAC Authorization V1 Beta 1 API", %{server: server} do
     cluster_roles =
-      Kazan.Apis.RbacAuthorizationV1beta1.list_cluster_role!()
+      RbacauthorizationV1beta1.list_cluster_role!()
       |> Kazan.Client.run!(server: server)
 
     assert cluster_roles.kind == "ClusterRoleList"

--- a/test/kazan/client_test.exs
+++ b/test/kazan/client_test.exs
@@ -1,9 +1,11 @@
 defmodule Kazan.ClientTest do
   use ExUnit.Case
 
+  alias Kazan.Apis.Core.V1, as: CoreV1
+
   setup do
     bypass = Bypass.open
-    request = Kazan.Apis.CoreV1.list_namespace!()
+    request = CoreV1.list_namespace!()
     server = %Kazan.Server{url: "http://localhost:#{bypass.port}"}
     {:ok, %{bypass: bypass, request: request, server: server}}
   end

--- a/test/kazan/request_test.exs
+++ b/test/kazan/request_test.exs
@@ -2,7 +2,7 @@ defmodule RequestTest do
   use ExUnit.Case, async: true
 
   alias Kazan.Request
-  alias Kazan.Models.Core.V1
+  alias Kazan.Apis.Core.V1, as: CoreV1
   alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
 
   describe "Request.create" do
@@ -40,7 +40,7 @@ defmodule RequestTest do
     end
 
     test "building a POST request" do
-      body_data = %V1.Binding{target: %V1.ObjectReference{}}
+      body_data = %CoreV1.Binding{target: %CoreV1.ObjectReference{}}
       {:ok, request} = Request.create(
         "createCoreV1NamespacedBinding",
         %{"namespace" => "test",
@@ -54,7 +54,7 @@ defmodule RequestTest do
     end
 
     test "building a PATCH request" do
-      body_data = %V1.Namespace{
+      body_data = %CoreV1.Namespace{
         metadata: %ObjectMeta{name: "test2"}
       }
       {:ok, request} = Request.create(

--- a/test/models_test.exs
+++ b/test/models_test.exs
@@ -2,9 +2,9 @@ defmodule KazanModelsTest do
   use ExUnit.Case
 
   alias Kazan.Models
-  alias Kazan.Models.Core
-  alias Kazan.Models.Extensions
-  alias Kazan.Models.Rbac
+  alias Kazan.Apis.Rbac
+  alias Kazan.Apis.Core
+  alias Kazan.Apis.Extensions
 
   test "that we have some models" do
     # Not a particularly thorough test, but whatever:


### PR DESCRIPTION
- API modules now have a `.` between their group & version names.
- Models now live under their associated API module where possible.