### PR TITLE
Add `Kazan.run` function, deprecate `Kazan.Client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ all APIs might be changed.
 
 - `Kazan.Models.oai_name_to_module` still supports the older OAI name format,
   but this is now deprecated and will be removed in a future version.
+- `Kazan.Client` has been deprecated in favor of exposing these functions in
+  `Kazan`.  See #23 for the justification.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ a kube service account.
 
 If your application is only going to be talking to a single kubernetes cluster,
 then it's recommended to configure that cluster in your mix config. This makes
-working with kazan slightly easier, as you can call `Kazan.Client.run` without
+working with kazan slightly easier, as you can call `Kazan.run` without
 providing a server every time.
 
 ### In Cluster Authentication
@@ -70,7 +70,7 @@ the kubernetes service account that can be configured like this:
 ```
 
 Alternatively, the `Kazan.Server.in_cluster` function can be used to create a
-server for passing straight into the `Kazan.Client`
+server for passing straight into `Kazan.run`
 
 ### Configuration via kube config file.
 
@@ -81,7 +81,7 @@ If you have a kube config file that contains the cluster & auth details you wish
 ```
 
 Alternatively, the `Kazan.Server.from_kubeconfig` function can be used to create a
-server for passing straight into the `Kazan.Client`
+server for passing straight into `Kazan.run`
 
 ### Configuring server details directly
 
@@ -98,7 +98,7 @@ See the `Kazan.Server` documentation to see what fields this supports.
 Making a request with Kazan is done in two stages.
 
 1. Build the request object using one of the functions in `Kazan.Api.*`.
-2. Run that request using `Kazan.Client`.
+2. Run that request using `Kazan.run`.
 
 For example, to get all of the pods from the server configured in the mix config:
 
@@ -114,7 +114,7 @@ Alternatively, you might want to specify the server to send the request to:
 server = Kazan.Server.in_cluster
 
 Kazan.Apis.Core.V1.list_pod_for_all_namespaces!
-|> Kazan.Client.run!(server: server)
+|> Kazan.run!(server: server)
 # %Kazan.Apis.Core.V1.PodList{...}
 ```
 

--- a/lib/kazan.ex
+++ b/lib/kazan.ex
@@ -25,7 +25,7 @@ defmodule Kazan do
 
   The server must be set in the kazan config.
   """
-  defdelegate run(request), to: Kazan.Client
+  defdelegate run(request), to: Kazan.Client.Imp
 
   @doc """
   Makes a request against a kube server.
@@ -38,17 +38,17 @@ defmodule Kazan do
   this request to. This will override any server provided in the Application
   config.
   """
-  defdelegate run(request, opts), to: Kazan.Client
+  defdelegate run(request, opts), to: Kazan.Client.Imp
 
   @doc """
   Like `run/2`, but raises on Error.  See `run/2` for more details.
   """
   @spec run!(Request.t, Keyword.t) :: struct | no_return
-  defdelegate run!(request, opts), to: Kazan.Client
+  defdelegate run!(request, opts), to: Kazan.Client.Imp
 
   @doc """
   Like `run/1`, but raises on Error.  See `run/1` for more details.
   """
   @spec run!(Request.t) :: struct | no_return
-  defdelegate run!(request), to: Kazan.Client
+  defdelegate run!(request), to: Kazan.Client.Imp
 end

--- a/lib/kazan.ex
+++ b/lib/kazan.ex
@@ -15,7 +15,7 @@ defmodule Kazan do
       used to build requests and can be received in responses from the API.
   - `Kazan.Models` contains other structs that can be sent and received by k8s,
     but are not specifically tied to any one API group.
-  - `Kazan.Client` is responsible for actually sending those requests.
+  - `Kazan.run` is responsible for actually sending those requests.
 
   See the [README](readme.html) for example usage.
   """

--- a/lib/kazan.ex
+++ b/lib/kazan.ex
@@ -19,4 +19,36 @@ defmodule Kazan do
 
   See the [README](readme.html) for example usage.
   """
+
+  @doc """
+  Makes a request against a kube server.
+
+  The server must be set in the kazan config.
+  """
+  defdelegate run(request), to: Kazan.Client
+
+  @doc """
+  Makes a request against a kube server.
+
+  The server should be set in the kazan config or provided in the options.
+
+  ### Options
+
+  * `server` - A `Kazan.Server` struct that defines which server we should send
+  this request to. This will override any server provided in the Application
+  config.
+  """
+  defdelegate run(request, opts), to: Kazan.Client
+
+  @doc """
+  Like `run/2`, but raises on Error.  See `run/2` for more details.
+  """
+  @spec run!(Request.t, Keyword.t) :: struct | no_return
+  defdelegate run!(request, opts), to: Kazan.Client
+
+  @doc """
+  Like `run/1`, but raises on Error.  See `run/1` for more details.
+  """
+  @spec run!(Request.t) :: struct | no_return
+  defdelegate run!(request), to: Kazan.Client
 end

--- a/lib/kazan/apis.ex
+++ b/lib/kazan/apis.ex
@@ -8,8 +8,8 @@ defmodule Kazan.Apis do
   Each of these modules will contain submodules that repreesent the different
   versions of the API group. Within those submodules will be functions that can
   be called to generate `Kazan.Request` structures that can be fed into
-  `Kazan.Client`. The version submodules will also contain any structs that can
-  be sent & received by that particular version of the API group.
+  `Kazan.run`. The version submodules will also contain any structs that can be
+  sent & received by that particular version of the API group.
 
   Each request functions arguments are generated so that any HTTP body parameter
   is first, followed by any path parameters in path order, followed by any

--- a/lib/kazan/client.ex
+++ b/lib/kazan/client.ex
@@ -3,22 +3,15 @@ defmodule Kazan.Client do
   Kazan.Client sends requests to a kubernetes server.
 
   These requests should be built using the functions in the `Kazan.Apis` module.
+
+  DEPRECATED: This module will become private API and/or removed in the
+  future. Use `run` in the `Kazan` module instead.
   """
   alias Kazan.{Request, Server}
 
   @type run_result :: {:ok, struct} | {:error, term}
 
-  @doc """
-  Makes a request against a kube server.
-
-  The server should be set in the kazan config or provided in the options.
-
-  ### Options
-
-  * `server` - A `Kazan.Server` struct that defines which server we should send
-    this request to. This will override any server provided in the Application
-    config.
-  """
+  @deprecated "Use Kazan.run instead"
   @spec run(Request.t, Keyword.t) :: run_result
   def run(request, options \\ []) do
     server = find_server(options)
@@ -50,9 +43,7 @@ defmodule Kazan.Client do
          do: {:ok, model}
   end
 
-  @doc """
-  Like `run/2`, but raises on Error.  See `run/2` for more details.
-  """
+  @deprecated "Use Kazan.run! instead"
   @spec run!(Request.t, Keyword.t) :: struct | no_return
   def run!(request, options \\ []) do
     case run(request, options) do

--- a/lib/kazan/client.ex
+++ b/lib/kazan/client.ex
@@ -1,115 +1,19 @@
 defmodule Kazan.Client do
   @moduledoc """
-  Kazan.Client sends requests to a kubernetes server.
-
-  These requests should be built using the functions in the `Kazan.Apis` module.
-
   DEPRECATED: This module will become private API and/or removed in the
-  future. Use `run` in the `Kazan` module instead.
+  future. Use the `Kazan` module instead.
   """
-  alias Kazan.{Request, Server}
-
   @type run_result :: {:ok, struct} | {:error, term}
 
-  @deprecated "Use Kazan.run instead"
-  @spec run(Request.t, Keyword.t) :: run_result
-  def run(request, options \\ []) do
-    server = find_server(options)
+  @deprecated "Use Kazan.run/1 instead"
+  defdelegate run(request), to: Kazan.Client.Imp
 
-    headers = [{"Accept", "application/json"}]
-    headers = headers ++ case request.content_type do
-                           nil -> []
-                           type -> [{"Content-Type", type}]
-                         end
+  @deprecated "Use Kazan.run/2 instead"
+  defdelegate run(request, opts), to: Kazan.Client.Imp
 
-    headers = headers ++ case server.auth do
-      %Server.TokenAuth{token: token} -> [{"Authorization", "Bearer #{token}"}]
-      _ -> []
-    end
+  @deprecated "Use Kazan.run!/1 instead"
+  defdelegate run!(request), to: Kazan.Client.Imp
 
-    res = HTTPoison.request(
-      method(request.method),
-      server.url <> request.path,
-      request.body || "",
-      headers,
-      params: request.query_params,
-      ssl: ssl_options(server)
-    )
-
-    with {:ok, result} <- res,
-         {:ok, body} <- check_status(result),
-         {:ok, data} <- Poison.decode(body),
-         {:ok, model} <- Kazan.Models.decode(data, request.response_schema),
-         do: {:ok, model}
-  end
-
-  @deprecated "Use Kazan.run! instead"
-  @spec run!(Request.t, Keyword.t) :: struct | no_return
-  def run!(request, options \\ []) do
-    case run(request, options) do
-      {:ok, result} -> result
-      {:error, reason} -> raise Kazan.RemoteError, reason: reason
-    end
-  end
-
-  # Figures out which server we should use.  In order of preference:
-  # - A server specified in the keyword arguments
-  # - A server specified in the kazan config
-  @spec find_server(Keyword.t) :: Server.t
-  defp find_server(options) do
-    case Keyword.get(options, :server) do
-      nil ->
-        case Application.get_env(:kazan, :server) do
-          nil ->
-            raise "No server is configured"
-          {:kubeconfig, filename} ->
-            Server.from_kubeconfig(filename)
-          {:kubeconfig, filename, opts} ->
-            Server.from_kubeconfig(filename, opts)
-          :in_cluster ->
-            Server.in_cluster
-          details ->
-            struct(Server, details)
-        end
-      server -> server
-    end
-  end
-
-  defp method("get"), do: :get
-  defp method("post"), do: :post
-  defp method("put"), do: :put
-  defp method("delete"), do: :delete
-  defp method("patch"), do: :patch
-
-  @spec check_status(HTTPoison.Response.t) :: {:ok, String.t}
-  defp check_status(%{status_code: code, body: body}) when code in 200..299 do
-    {:ok, body}
-  end
-  defp check_status(%{status_code: other, body: body}) do
-    data =
-      case Poison.decode(body) do
-        {:ok, data} -> data
-        _ -> body
-      end
-    {:error, {:http_error, other, data}}
-  end
-
-  @spec ssl_options(Server.t) :: Keyword.t
-  defp ssl_options(server) do
-    auth_options = ssl_auth_options(server.auth)
-    verify_options = case server.insecure_skip_tls_verify do
-      true -> [verify: :verify_none]
-      _ -> []
-    end
-    ca_options = case server.ca_cert do
-      nil -> []
-      cert -> [cacerts: [cert]]
-    end
-    auth_options ++ verify_options ++ ca_options
-  end
-
-  defp ssl_auth_options(%Server.CertificateAuth{certificate: cert, key: key}) do
-    [cert: cert, key: key]
-  end
-  defp ssl_auth_options(_), do: []
+  @deprecated "Use Kazan.run!/2 instead"
+  defdelegate run!(request, opts), to: Kazan.Client.Imp
 end

--- a/lib/kazan/client/imp.ex
+++ b/lib/kazan/client/imp.ex
@@ -1,0 +1,123 @@
+defmodule Kazan.Client.Imp do
+  @moduledoc false
+  # Kazan.Client sends requests to a kubernetes server.
+  # These requests should be built using the functions in the `Kazan.Apis` module.
+
+  alias Kazan.{Request, Server}
+
+  @type run_result :: {:ok, struct} | {:error, term}
+
+  @doc """
+  Makes a request against a kube server.
+
+  The server should be set in the kazan config or provided in the options.
+
+  ### Options
+
+  * `server` - A `Kazan.Server` struct that defines which server we should send
+  this request to. This will override any server provided in the Application
+  config.
+  """
+  @spec run(Request.t, Keyword.t) :: run_result
+  def run(request, options \\ []) do
+    server = find_server(options)
+
+    headers = [{"Accept", "application/json"}]
+    headers = headers ++ case request.content_type do
+                           nil -> []
+                           type -> [{"Content-Type", type}]
+                         end
+
+    headers = headers ++ case server.auth do
+      %Server.TokenAuth{token: token} -> [{"Authorization", "Bearer #{token}"}]
+      _ -> []
+    end
+
+    res = HTTPoison.request(
+      method(request.method),
+      server.url <> request.path,
+      request.body || "",
+      headers,
+      params: request.query_params,
+      ssl: ssl_options(server)
+    )
+
+    with {:ok, result} <- res,
+         {:ok, body} <- check_status(result),
+         {:ok, data} <- Poison.decode(body),
+         {:ok, model} <- Kazan.Models.decode(data, request.response_schema),
+         do: {:ok, model}
+  end
+
+  @doc """
+  Like `run`, but raises on Error.  See `run/2` for more details.
+  """
+  @spec run!(Request.t, Keyword.t) :: struct | no_return
+  def run!(request, options \\ []) do
+    case run(request, options) do
+      {:ok, result} -> result
+      {:error, reason} -> raise Kazan.RemoteError, reason: reason
+    end
+  end
+
+  # Figures out which server we should use.  In order of preference:
+  # - A server specified in the keyword arguments
+  # - A server specified in the kazan config
+  @spec find_server(Keyword.t) :: Server.t
+  defp find_server(options) do
+    case Keyword.get(options, :server) do
+      nil ->
+        case Application.get_env(:kazan, :server) do
+          nil ->
+            raise "No server is configured"
+          {:kubeconfig, filename} ->
+            Server.from_kubeconfig(filename)
+          {:kubeconfig, filename, opts} ->
+            Server.from_kubeconfig(filename, opts)
+          :in_cluster ->
+            Server.in_cluster
+          details ->
+            struct(Server, details)
+        end
+      server -> server
+    end
+  end
+
+  defp method("get"), do: :get
+  defp method("post"), do: :post
+  defp method("put"), do: :put
+  defp method("delete"), do: :delete
+  defp method("patch"), do: :patch
+
+  @spec check_status(HTTPoison.Response.t) :: {:ok, String.t}
+  defp check_status(%{status_code: code, body: body}) when code in 200..299 do
+    {:ok, body}
+  end
+  defp check_status(%{status_code: other, body: body}) do
+    data =
+      case Poison.decode(body) do
+        {:ok, data} -> data
+        _ -> body
+      end
+    {:error, {:http_error, other, data}}
+  end
+
+  @spec ssl_options(Server.t) :: Keyword.t
+  defp ssl_options(server) do
+    auth_options = ssl_auth_options(server.auth)
+    verify_options = case server.insecure_skip_tls_verify do
+      true -> [verify: :verify_none]
+      _ -> []
+    end
+    ca_options = case server.ca_cert do
+      nil -> []
+      cert -> [cacerts: [cert]]
+    end
+    auth_options ++ verify_options ++ ca_options
+  end
+
+  defp ssl_auth_options(%Server.CertificateAuth{certificate: cert, key: key}) do
+    [cert: cert, key: key]
+  end
+  defp ssl_auth_options(_), do: []
+end

--- a/lib/kazan/codegen/apis.ex
+++ b/lib/kazan/codegen/apis.ex
@@ -304,7 +304,7 @@ defmodule Kazan.Codegen.Apis do
 
         This module contains functions that can be used to query the avaliable
         versions of the #{group} API in a k8s server. Each of these functions
-        will output a `Kazan.Request` suitable for passing to `Kazan.Client`.
+        will output a `Kazan.Request` suitable for passing to `Kazan.run`.
 
         The submodules of this module provide implementations of each of those
         versions.
@@ -314,7 +314,7 @@ defmodule Kazan.Codegen.Apis do
         Contains functions for #{version} of the #{group} API group.
 
         Each of these functions will output a `Kazan.Request` suitable for passing
-        to `Kazan.Client`.
+        to `Kazan.run`.
 
         This module also contains struct submodules that can be sent & received
         from this version of the #{group} API.

--- a/lib/kazan/request.ex
+++ b/lib/kazan/request.ex
@@ -1,6 +1,9 @@
 defmodule Kazan.Request do
   @moduledoc """
   Kazan.Request is a struct that describes an HTTP request.
+
+  Users should mostly treat this struct as opaque - `Kazan.run` consumes it, and
+  functions in the various `Kazan.Apis` submodules construct it.
   """
   defstruct [:method, :path, :query_params, :content_type, :body, :response_schema]
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -24,7 +24,7 @@ defmodule KazanIntegrationTest do
   test "can list namespaces on an actual server", %{server: server} do
     namespace_list =
       CoreV1.list_namespace!
-      |> Kazan.Client.run!(server: server)
+      |> Kazan.run!(server: server)
 
     # Check that there's a default namespace.
     assert Enum.find(namespace_list.items, fn (namespace) ->
@@ -34,12 +34,12 @@ defmodule KazanIntegrationTest do
 
   test "can list pods on an actual server", %{server: server} do
     CoreV1.list_namespaced_pod!(@namespace)
-    |> Kazan.Client.run!(server: server)
+    |> Kazan.run!(server: server)
   end
 
   test "can list deployments on an actual server", %{server: server} do
     ExtensionsV1beta1.list_namespaced_deployment!(@namespace)
-    |> Kazan.Client.run!(server: server)
+    |> Kazan.run!(server: server)
   end
 
   test "can create, patch and delete a pod", %{server: server} do
@@ -59,11 +59,11 @@ defmodule KazanIntegrationTest do
         },
         @namespace
       )
-      |> Kazan.Client.run!(server: server)
+      |> Kazan.run!(server: server)
 
     read_pod =
       CoreV1.read_namespaced_pod!(@namespace, "kazan-test")
-      |> Kazan.Client.run!(server: server)
+      |> Kazan.run!(server: server)
 
     assert read_pod.spec == %{created_pod.spec | node_name: read_pod.spec.node_name}
 
@@ -76,26 +76,26 @@ defmodule KazanIntegrationTest do
       },
       @namespace,
       "kazan-test"
-    ) |> Kazan.Client.run!(server: server)
+    ) |> Kazan.run!(server: server)
 
     assert patched_pod.spec == %{read_pod.spec | active_deadline_seconds: 5}
 
     read_pod =
       CoreV1.read_namespaced_pod!(@namespace, "kazan-test")
-      |> Kazan.Client.run!(server: server)
+      |> Kazan.run!(server: server)
 
     assert read_pod == patched_pod
 
     CoreV1.delete_namespaced_pod!(
       %DeleteOptions{}, @namespace, "kazan-test"
     )
-    |> Kazan.Client.run!(server: server)
+    |> Kazan.run!(server: server)
   end
 
   test "RBAC Authorization V1 Beta 1 API", %{server: server} do
     cluster_roles =
       RbacauthorizationV1beta1.list_cluster_role!()
-      |> Kazan.Client.run!(server: server)
+      |> Kazan.run!(server: server)
 
     assert cluster_roles.kind == "ClusterRoleList"
     assert cluster_roles.items == []

--- a/test/kazan/client_imp_test.exs
+++ b/test/kazan/client_imp_test.exs
@@ -1,4 +1,4 @@
-defmodule Kazan.ClientTest do
+defmodule Kazan.Client.ImpTest do
   use ExUnit.Case
 
   alias Kazan.Apis.Core.V1, as: CoreV1
@@ -10,8 +10,8 @@ defmodule Kazan.ClientTest do
     {:ok, %{bypass: bypass, request: request, server: server}}
   end
 
-  describe "Client.run" do
-    import Kazan.Client, only: [run: 2]
+  describe "Client.Imp.run" do
+    import Kazan.Client.Imp, only: [run: 2]
 
     test "returns decoded data if everything is good", context do
       %{request: request, bypass: bypass, server: server} = context
@@ -67,8 +67,8 @@ defmodule Kazan.ClientTest do
     end
   end
 
-  describe "Client.run!" do
-    import Kazan.Client, only: [run!: 2]
+  describe "Client.Imp.run!" do
+    import Kazan.Client.Imp, only: [run!: 2]
 
     test "returns decoded data if everything is good", context do
       %{request: request, bypass: bypass, server: server} = context


### PR DESCRIPTION
`Kazan` only really has one job - talking to kubernetes.  It doesn't make much
sense for the primary function for talking to kubernetes to be hidden inside
`Kazan.Client` while the `Kazan` module goes unused.

So, this commit deprecates `Kazan.Client` and presents the `Kazan.run` &
`Kazan.run!` functions as alternatives.