### PR TITLE
Add pattern matches to `Kazan.run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ all APIs might be changed.
 
 ## Unreleased - yyyy-mm-dd
 
-Nothing yet.
+### Changes
+
+- `Kazan.run` now pattern matches on argument types, so if a user accidentally
+  passes a `{:ok, request}` to it, they'll get a better error message.
 
 ## v0.6.0 - 2018-02-19
 

--- a/lib/kazan/client/imp.ex
+++ b/lib/kazan/client/imp.ex
@@ -19,7 +19,7 @@ defmodule Kazan.Client.Imp do
   config.
   """
   @spec run(Request.t(), Keyword.t()) :: run_result
-  def run(request, options \\ []) do
+  def run(%Request{} = request, options \\ []) do
     server = find_server(options)
 
     headers = [{"Accept", "application/json"}]
@@ -99,7 +99,7 @@ defmodule Kazan.Client.Imp do
   Like `run`, but raises on Error.  See `run/2` for more details.
   """
   @spec run!(Request.t(), Keyword.t()) :: struct | no_return
-  def run!(request, options \\ []) do
+  def run!(%Request{} = request, options \\ []) do
     case run(request, options) do
       {:ok, result} -> result
       {:error, reason} -> raise Kazan.RemoteError, reason: reason


### PR DESCRIPTION
So we get better error messages if someone passes the output from a
non-bang function straight into these.