### PR TITLE
Allow token use in server auth config

### DIFF
--- a/lib/kazan/client/imp.ex
+++ b/lib/kazan/client/imp.ex
@@ -37,6 +37,9 @@ defmodule Kazan.Client.Imp do
           %Server.TokenAuth{token: token} ->
             [{"Authorization", "Bearer #{token}"}]
 
+          %{token: token} ->
+            [{"Authorization", "Bearer #{token}"}]
+
           _ ->
             []
         end


### PR DESCRIPTION
When using Kazan in our projects, we tend to use an auth token as opposed to passing the kubeconfig path like it is mentioned in the Kazan README. The issue we have had is that the auth header is not added to requests when using the following config because it does not match when building the list of headers.

```
config :kazan, :server, %{
  url: <url>,
  auth: %{
    token: <token>
  }
}
```

We have been using these changes [in the PR] to use an auth token from the config. Is there a better/preferred way to accomplish this or should we consider merging this in to allow for this use case?