### PR TITLE
Support for specifying auth directly in mix config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ all APIs might be changed.
 
 - Handle the breaking change to `YamlElixir.read_from_file` in YamlElixir 1.4.0
 
+### Bug Fixes
+
+- Token & certificate auth details can now be supplied in the mix config.
+
 ## v0.6.0 - 2018-02-19
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,6 @@ all APIs might be changed.
 ### Bug Fixes
 
 - Handle the breaking change to `YamlElixir.read_from_file` in YamlElixir 1.4.0
-
-### Bug Fixes
-
 - Token & certificate auth details can now be supplied in the mix config.
 
 ## v0.6.0 - 2018-02-19

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
 ```elixir
 def deps do
-  [{:kazan, "~> 0.1"}]
+  [{:kazan, "~> 0.6"}]
 end
 ```
 
@@ -81,7 +81,8 @@ server for passing straight into `Kazan.run`
 
 ### Configuration via kube config file.
 
-If you have a kube config file that contains the cluster & auth details you wish to use, kazan can use that:
+If you have a kube config file that contains the cluster & auth details you wish
+to use, kazan can use that:
 
 ```elixir
 config :kazan, :server, {:kubeconfig, "path/to/file"}
@@ -92,13 +93,15 @@ server for passing straight into `Kazan.run`
 
 ### Configuring server details directly
 
-If you wish to configure the server details manually, kazan can also accept a map of server parameters:
+If you wish to configure the server details manually, kazan can also accept a
+map of server parameters:
 
 ```elixir
-config :kazan, :server, %{url: "kubernetes.default"}
+config :kazan, :server, %{url: "kubernetes.default" auth: %{token: "your_token"}}
 ```
 
-See the [`Kazan.Server` documentation](https://hexdocs.pm/kazan/Kazan.Server.html) to see what fields
+See the [`Kazan.Server`
+documentation](https://hexdocs.pm/kazan/Kazan.Server.html) to see what fields
 this supports.
 
 ## Usage

--- a/lib/kazan/client/imp.ex
+++ b/lib/kazan/client/imp.ex
@@ -113,6 +113,7 @@ defmodule Kazan.Client.Imp do
   defp find_server(options) do
     case Keyword.get(options, :server) do
       nil ->
+        # TODO: Consider breaking this whole block out into Kazan.Server
         case Application.get_env(:kazan, :server) do
           nil ->
             raise "No server is configured"
@@ -126,8 +127,9 @@ defmodule Kazan.Client.Imp do
           :in_cluster ->
             Server.in_cluster()
 
-          details ->
-            struct(Server, details)
+          # TODO: tests & docs.
+          %{} = map ->
+            Server.from_map(map)
         end
 
       server ->

--- a/lib/kazan/server.ex
+++ b/lib/kazan/server.ex
@@ -92,8 +92,9 @@ defmodule Kazan.Server do
   # Server.from_map can be used to convert a map into a Server.t. Useful when
   # working with mix config, where the kazan structs are unavaliable.
   @doc false
-  @spec from_map(Server.t | Map.t) :: Server.t
+  @spec from_map(Server.t() | Map.t()) :: Server.t()
   def from_map(%Server{} = server), do: server
+
   def from_map(%{} = map) do
     server = struct(Server, map)
 
@@ -101,13 +102,16 @@ defmodule Kazan.Server do
       case server.auth do
         %{token: _} = token_auth ->
           struct(Server.TokenAuth, token_auth)
+
         %{certificate: _, key: _} = cert_auth ->
           struct(Server.CertificateAuth, cert_auth)
+
         nil ->
           nil
+
         other ->
           raise """
-          Unknown kazan auth map format: #{inspect other}".
+          Unknown kazan auth map format: #{inspect(other)}".
 
           See Kazan.Server.from_map/1
           """

--- a/test/kazan/server_test.exs
+++ b/test/kazan/server_test.exs
@@ -1,11 +1,13 @@
 defmodule Kazan.ServerTest do
   use ExUnit.Case
 
+  alias Kazan.Server
+  alias Kazan.Server.{CertificateAuth, TokenAuth}
+
   describe "Server.from_kubeconfig" do
-    import Kazan.Server, only: [from_kubeconfig: 1, from_kubeconfig: 2]
 
     test "loads default context" do
-      config = from_kubeconfig("test/test_data/kubeconfig")
+      config = Server.from_kubeconfig("test/test_data/kubeconfig")
       assert config.url == "https://172.17.4.99:443"
       assert config.ca_cert
       assert config.auth
@@ -15,7 +17,7 @@ defmodule Kazan.ServerTest do
 
     test "can load other context" do
       config =
-        from_kubeconfig("test/test_data/kubeconfig", context: "other-context")
+        Server.from_kubeconfig("test/test_data/kubeconfig", context: "other-context")
 
       assert config.url == "https://172.17.4.99:443"
       assert config.ca_cert
@@ -23,11 +25,34 @@ defmodule Kazan.ServerTest do
     end
 
     test "can load non default user" do
-      config = from_kubeconfig("test/test_data/kubeconfig", user: "other-user")
+      config = Server.from_kubeconfig("test/test_data/kubeconfig", user: "other-user")
 
       assert config.url == "https://172.17.4.99:443"
       assert config.ca_cert
       refute config.auth
+    end
+  end
+
+  describe "Server.from_map" do
+    test "converts the map into a server struct" do
+      server = Server.from_map(%{url: "http://example.com", ca_cert: "abcd", insecure_skip_tls_verify: false})
+      assert server == %Server{url: "http://example.com", ca_cert: "abcd", insecure_skip_tls_verify: false, auth: nil}
+    end
+
+    test "converts token auth" do
+      server = Server.from_map(%{auth: %{token: "abcde"}})
+      assert server.auth == %TokenAuth{token: "abcde"}
+    end
+
+    test "converts certificate auth" do
+      server = Server.from_map(%{auth: %{certificate: "abcde", key: "fghij"}})
+      assert server.auth == %CertificateAuth{certificate: "abcde", key: "fghij"}
+    end
+
+    test "raises on unknown auth" do
+      assert_raise RuntimeError, fn ->
+        Server.from_map(%{auth: %{something: "abcd"}})
+      end
     end
   end
 end

--- a/test/kazan/server_test.exs
+++ b/test/kazan/server_test.exs
@@ -5,7 +5,6 @@ defmodule Kazan.ServerTest do
   alias Kazan.Server.{CertificateAuth, TokenAuth}
 
   describe "Server.from_kubeconfig" do
-
     test "loads default context" do
       config = Server.from_kubeconfig("test/test_data/kubeconfig")
       assert config.url == "https://172.17.4.99:443"
@@ -17,7 +16,10 @@ defmodule Kazan.ServerTest do
 
     test "can load other context" do
       config =
-        Server.from_kubeconfig("test/test_data/kubeconfig", context: "other-context")
+        Server.from_kubeconfig(
+          "test/test_data/kubeconfig",
+          context: "other-context"
+        )
 
       assert config.url == "https://172.17.4.99:443"
       assert config.ca_cert
@@ -25,7 +27,8 @@ defmodule Kazan.ServerTest do
     end
 
     test "can load non default user" do
-      config = Server.from_kubeconfig("test/test_data/kubeconfig", user: "other-user")
+      config =
+        Server.from_kubeconfig("test/test_data/kubeconfig", user: "other-user")
 
       assert config.url == "https://172.17.4.99:443"
       assert config.ca_cert
@@ -35,8 +38,19 @@ defmodule Kazan.ServerTest do
 
   describe "Server.from_map" do
     test "converts the map into a server struct" do
-      server = Server.from_map(%{url: "http://example.com", ca_cert: "abcd", insecure_skip_tls_verify: false})
-      assert server == %Server{url: "http://example.com", ca_cert: "abcd", insecure_skip_tls_verify: false, auth: nil}
+      server =
+        Server.from_map(%{
+          url: "http://example.com",
+          ca_cert: "abcd",
+          insecure_skip_tls_verify: false
+        })
+
+      assert server == %Server{
+               url: "http://example.com",
+               ca_cert: "abcd",
+               insecure_skip_tls_verify: false,
+               auth: nil
+             }
     end
 
     test "converts token auth" do


### PR DESCRIPTION
The documentation for Kazan says that we support specifying a server map
in the mix config.  This was true, but the auth map within the config
was not being converted to one of the `Kazan.Server.*` structs. This
meant that the `Kazan.run` calls would fail as they pattern match on the
struct type.

This updates `Kazan.Server` with a function that properly converts maps
to the appropriate nested structs, which should allow people to specify
the auth details in their mix config.

Fixes #39