### PR TITLE
Use YamlElixir 2.0

### DIFF
--- a/lib/kazan/server.ex
+++ b/lib/kazan/server.ex
@@ -34,19 +34,7 @@ defmodule Kazan.Server do
   """
   @spec from_kubeconfig(String.t(), Keyword.t()) :: t
   def from_kubeconfig(config_file, options \\ []) do
-    # YamlElixir made a breaking change in a minor version, so we need to make
-    # sure we call the appropriate function for the version installed.
-    # Can hopefully get rid of this at some point.
-    Code.ensure_loaded(YamlElixir)
-
-    func =
-      if Kernel.function_exported?(YamlElixir, :read_from_file!, 1) do
-        :read_from_file!
-      else
-        :read_from_file
-      end
-
-    data = apply(YamlElixir, func, [config_file])
+    data = YamlElixir.read_from_file!(config_file)
 
     basepath = config_file |> Path.absname() |> Path.dirname()
 

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Kazan.Mixfile do
   defp deps do
     [{:poison, "~> 2.0 or ~> 3.0"},
      {:httpoison, "~> 0.10 or ~> 1.0"},
-     {:yaml_elixir, "~> 1.3"},
+     {:yaml_elixir, "~> 2.0"},
 
      # Dev dependencies
      {:ex_doc, "~> 0.14", only: :dev},


### PR DESCRIPTION
YamlElixir 2.0 is functionally identical to 1.3, except for the [breaking API change](https://github.com/KamilLelonek/yaml-elixir/pull/24#pullrequestreview-109019520) which was initially introduced in 1.4. Updating the version constraint to 2.0 allows us to remove the 1.3/1.4 negotiation hack.

Sorry again for the breaking change. My fault for thinking I had internalised SemVer rules!