### PR TITLE
Add support for auth-provider user auth in kubeconfig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ otp_release:
   - 20.2
 script:
   - mix test
-  - if [ "$TRAVIS_ELIXIR_VERSION" = "1.6.0" ]; then mix format --check-formatted; fi
+  - if [[ "$TRAVIS_ELIXIR_VERSION" =~ "1.6.[[:digit:]]" ]]; then mix format --check-formatted; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 elixir:
   - 1.5.3
-  - 1.6.0
+  - 1.6.4
 otp_release:
   - 19.2
   - 20.2

--- a/lib/kazan/server.ex
+++ b/lib/kazan/server.ex
@@ -162,10 +162,8 @@ defmodule Kazan.Server do
       "token-key" => token_key
     } = auth_config
 
-    token = resolve_token(cmd_path, cmd_args, token_key)
-
     %Kazan.Server.TokenAuth{
-      token: token
+      token: resolve_token(cmd_path, cmd_args, token_key)
     }
   end
 
@@ -177,10 +175,14 @@ defmodule Kazan.Server do
     with {cmd_response, 0} = System.cmd(cmd_path, String.split(cmd_args, " ")),
          {:ok, data} = Poison.decode(cmd_response) do
       token_key
-      |> String.slice(1, String.length(token_key) - 2) # remove enclosing { and }
-      |> String.split(".") # split ".credential.access_token" into ["", "credential", "access_token"]
-      |> Enum.reject(fn key -> key == "" end) # remove the leading empty
-      |> Enum.reduce(data, fn key, data -> Map.get(data, key) end) # traverse the dictionary using the keys
+      # remove enclosing { and }
+      |> String.slice(1, String.length(token_key) - 2)
+      # split ".credential.access_token" into ["", "credential", "access_token"]
+      |> String.split(".")
+      # remove the leading empty
+      |> Enum.reject(fn key -> key == "" end)
+      # traverse the dictionary using the keys
+      |> Enum.reduce(data, fn key, data -> Map.get(data, key) end)
     end
   end
 

--- a/test/kazan/server_test.exs
+++ b/test/kazan/server_test.exs
@@ -34,6 +34,12 @@ defmodule Kazan.ServerTest do
       assert config.ca_cert
       refute config.auth
     end
+
+    test "can load user from auth-provider" do
+      config =
+        Server.from_kubeconfig("test/test_data/kubeconfig", user: "user-with-auth-provider")
+      assert config.auth == %TokenAuth{token: "the-token"}
+    end
   end
 
   describe "Server.from_map" do

--- a/test/kazan/server_test.exs
+++ b/test/kazan/server_test.exs
@@ -37,7 +37,11 @@ defmodule Kazan.ServerTest do
 
     test "can load user from auth-provider" do
       config =
-        Server.from_kubeconfig("test/test_data/kubeconfig", user: "user-with-auth-provider")
+        Server.from_kubeconfig(
+          "test/test_data/kubeconfig",
+          user: "user-with-auth-provider"
+        )
+
       assert config.auth == %TokenAuth{token: "the-token"}
     end
   end

--- a/test/test_data/kubeconfig
+++ b/test/test_data/kubeconfig
@@ -22,5 +22,14 @@ users:
     client-key: ssl/admin-key.pem
 - name: other-user
   user:
+- name: user-with-auth-provider
+  user:
+    auth-provider:
+      config:
+        cmd-args: "{\"credential\": {\"access_token\": \"the-token\"}}"
+        cmd-path: echo
+        token-key: '{.credential.access_token}'
+      name: gcp
+
 current-context: vagrant-single
 


### PR DESCRIPTION
GCP uses a gcloud for auth an dynamically generates a token in order to access hosted K8s clusters.
This PR adds support for that. 

Please let me know if there's anything you'd suggest I change.