### PR TITLE
Update test dependencies for Plug v1.7.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Kazan.Mixfile do
      {:ex_doc, "~> 0.14", only: :dev},
 
      # Test dependencies
-     {:cowboy, "~> 1.0", only: :test},
+     {:plug_cowboy, "~> 1.0", only: :test},
      {:bypass, "~> 0.5", only: :test}
    ]
   end


### PR DESCRIPTION
The newest release of Plug [extracted the cowboy adapter](https://github.com/elixir-plug/plug/blob/7b83496207eff567ec72d91d7e9c5e1eaaa2f013/CHANGELOG.md#enhancements) into a [separate project](https://github.com/elixir-plug/plug_cowboy). Getting the tests to run now requires either using `plug_cowboy` or pinning `plug` to < 1.7.0. Otherwise there are a bunch of failures similar to:

```
warning: please add the following dependency to your mix.exs:

    {:plug_cowboy, "~> 1.0"}

This dependency is required by Plug.Adapters.Cowboy
which you may be using directly or indirectly.
Note you no longer need to depend on :cowboy directly.

  (plug) lib/plug/adapters/cowboy.ex:44: Plug.Adapters.Cowboy.warn_and_raise/0
  (plug) lib/plug/adapters/cowboy.ex:11: Plug.Adapters.Cowboy.http/3
  (bypass) lib/bypass/instance.ex:271: Bypass.Instance.do_up/3
  (bypass) lib/bypass/instance.ex:37: Bypass.Instance.init/1
  (stdlib) gen_server.erl:374: :gen_server.init_it/2
  (stdlib) gen_server.erl:342: :gen_server.init_it/6
  (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3



  1) test Client.Imp.run raises if auth is unresolved ProviderAuth (Kazan.Client.ImpTest)
     test/kazan/client_imp_test.exs:156
     ** (ArgumentError) argument error
     stacktrace:
       :erlang.apply({:error, {%RuntimeError{message: "plug_cowboy dependency missing"}, [{Plug.Adapters.Cowboy, :warn_and_raise, 0, [file: 'lib/plug/adapters/cowboy.ex', line: 54]}, {Plug.Adapters.Cowboy, :http, 3, [file: 'lib/plug/adapters/cowboy.ex', line: 11]}, {Bypass.Instance, :do_up, 3, [file: 'lib/bypass/instance.ex', line: 271]},
{Bypass.Instance, :init, 1, [file: 'lib/bypass/instance.ex', line: 37]}, {:gen_server, :init_it, 2, [file: 'gen_server.erl', line: 374]}, {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 342]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}, :port, [])
       test/kazan/client_imp_test.exs:9: Kazan.Client.ImpTest.__ex_unit_setup_0/1
       test/kazan/client_imp_test.exs:1: Kazan.Client.ImpTest.__ex_unit__/2
```