### PR TITLE
Allow users to provide their own OAI specs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ all APIs might be changed.
 - `Kazan.Server` now exposes `from_env/1` and `from_env!/0` functions for
   creating a `Kazan.Server` from application config. This should make it easier
   for users using GCP to continue to use application config.
+- Added some new configuration options that allow users to provide their own
+  OpenAPI spec files.   This should let users use kazan when they have
+  k8s extensions installed.
 
 ## v0.10.0 - 2018-10-17
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,8 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+
+if Mix.env() == :test do
+  config :kazan,
+    oai_name_mappings: [{"something.test", Kazan.Something}]
+end

--- a/lib/kazan/apis.ex
+++ b/lib/kazan/apis.ex
@@ -25,7 +25,7 @@ defmodule Kazan.Apis do
 
   alias Kazan.Codegen
 
-  Codegen.Apis.from_spec("kube_specs/swagger.json")
+  Codegen.Apis.from_spec()
 
   @doc """
   Maps OpenAPI spec operation IDs into functions that implement that operation.
@@ -44,9 +44,7 @@ defmodule Kazan.Apis do
 
       operation ->
         bang_function_name =
-          String.to_existing_atom(
-            Atom.to_string(operation.function_name) <> "!"
-          )
+          String.to_existing_atom(Atom.to_string(operation.function_name) <> "!")
 
         [
           {operation.api_module, operation.function_name},

--- a/lib/kazan/codegen/apis.ex
+++ b/lib/kazan/codegen/apis.ex
@@ -19,7 +19,9 @@ defmodule Kazan.Codegen.Apis do
   Currently the operationId has some tag-related data embedded in it, which we
   remove for the sake of brevity.
   """
-  defmacro from_spec(spec_file) do
+  defmacro from_spec() do
+    spec_file = Kazan.Config.oai_spec()
+
     operations =
       File.read!(spec_file)
       |> Poison.decode!()
@@ -130,19 +132,16 @@ defmodule Kazan.Codegen.Apis do
   # Builds the quoted function form for an operation function.
   @spec function_form(Operation.t()) :: term
   defp function_form(operation) do
-    param_groups =
-      Enum.group_by(operation.parameters, fn param -> param.type end)
+    param_groups = Enum.group_by(operation.parameters, fn param -> param.type end)
 
     is_required = fn param -> param.required end
     query_params = Map.get(param_groups, :query, [])
 
-    path_params =
-      param_groups |> Map.get(:path, []) |> sort_path_params(operation.path)
+    path_params = param_groups |> Map.get(:path, []) |> sort_path_params(operation.path)
 
     # The main arguments our function will take:
     argument_params =
-      Map.get(param_groups, :body, []) ++
-        path_params ++ Enum.filter(query_params, is_required)
+      Map.get(param_groups, :body, []) ++ path_params ++ Enum.filter(query_params, is_required)
 
     optional_params = Enum.reject(query_params, is_required)
 
@@ -197,8 +196,7 @@ defmodule Kazan.Codegen.Apis do
         {parameter.var_name, parameter.field_name}
       end
 
-    bang_function_name =
-      String.to_atom(Atom.to_string(operation.function_name) <> "!")
+    bang_function_name = String.to_atom(Atom.to_string(operation.function_name) <> "!")
 
     argument_forms_in_call =
       argument_call_forms(
@@ -224,13 +222,9 @@ defmodule Kazan.Codegen.Apis do
       end
 
       @doc unquote(docs)
-      @spec unquote(bang_function_name)(unquote_splicing(argument_specs)) ::
-              Kazan.Request.t()
+      @spec unquote(bang_function_name)(unquote_splicing(argument_specs)) :: Kazan.Request.t()
       def unquote(bang_function_name)(unquote_splicing(arguments)) do
-        rv =
-          unquote(operation.function_name)(
-            unquote_splicing(argument_forms_in_call)
-          )
+        rv = unquote(operation.function_name)(unquote_splicing(argument_forms_in_call))
 
         case rv do
           {:ok, result} ->
@@ -261,8 +255,7 @@ defmodule Kazan.Codegen.Apis do
   end
 
   defp argument_forms(argument_params, _optional_params) do
-    argument_forms(argument_params, []) ++
-      [{:\\, [], [Macro.var(:options, __MODULE__), []]}]
+    argument_forms(argument_params, []) ++ [{:\\, [], [Macro.var(:options, __MODULE__), []]}]
   end
 
   # List of argument specs to go in function spec.
@@ -274,8 +267,7 @@ defmodule Kazan.Codegen.Apis do
   end
 
   defp argument_spec_forms(argument_params, optional_params) do
-    argument_spec_forms(argument_params, []) ++
-      [optional_param_spec(optional_params)]
+    argument_spec_forms(argument_params, []) ++ [optional_param_spec(optional_params)]
   end
 
   # Generates a spec for an optional Keyword list.

--- a/lib/kazan/codegen/models.ex
+++ b/lib/kazan/codegen/models.ex
@@ -18,7 +18,8 @@ defmodule Kazan.Codegen.Models do
   It will also generate some model description data that can be used to write
   serializers/deserializers for each of the structs.
   """
-  defmacro from_spec(spec_file) do
+  defmacro from_spec() do
+    spec_file = Kazan.Config.oai_spec()
     models = parse_models(spec_file)
     resource_id_index = build_resource_id_index(models)
 
@@ -101,7 +102,7 @@ defmodule Kazan.Codegen.Models do
     end
   end
 
-  @spec typespec_for_property(PropertyDesc.t) :: [{atom, term}]
+  @spec typespec_for_property(PropertyDesc.t()) :: [{atom, term}]
   defp typespec_for_property(%PropertyDesc{ref: model})
        when not is_nil(model) do
     quote do

--- a/lib/kazan/config.ex
+++ b/lib/kazan/config.ex
@@ -1,0 +1,29 @@
+defmodule Kazan.Config do
+  @moduledoc false
+
+  # Loads the swagger filename from the config
+  def oai_spec() do
+    case Application.get_env(:kazan, :oai_spec) do
+      nil ->
+        "kube_specs/swagger.json"
+
+      filename ->
+        filename
+    end
+  end
+
+  def oai_name_mappings do
+    Application.get_env(:kazan, :oai_name_mappings, [])
+    |> Enum.map(fn {oai_prefix, module_prefix} ->
+      {ensure_ends_with_dot(oai_prefix), module_prefix}
+    end)
+  end
+
+  defp ensure_ends_with_dot(name) do
+    if String.ends_with?(name, ".") do
+      name
+    else
+      name <> "."
+    end
+  end
+end

--- a/lib/kazan/errors.ex
+++ b/lib/kazan/errors.ex
@@ -19,3 +19,17 @@ defmodule Kazan.BuildRequestError do
     "Error when building #{error.operation} request: #{error.reason}"
   end
 end
+
+defmodule Kazan.UnknownName do
+  @moduledoc """
+  Raised when we come across a k8s api/model who's name we don't know how to
+  map to an elixir module.
+
+  Can be fixed by setting `oai_name_mappings` in config.
+  """
+  defexception [:name]
+
+  def message(error) do
+    "Could not map #{error.name} into an elixir module.   Please ensure that oai_name_mappings is set correctly"
+  end
+end

--- a/lib/kazan/models.ex
+++ b/lib/kazan/models.ex
@@ -12,7 +12,7 @@ defmodule Kazan.Models do
   alias Kazan.Codegen
   alias Kazan.Codegen.Models.{ModelDesc, PropertyDesc, ResourceId}
 
-  Codegen.Models.from_spec("kube_specs/swagger.json")
+  Codegen.Models.from_spec()
 
   @doc """
   Decodes data from a Map into a Model struct.
@@ -43,7 +43,7 @@ defmodule Kazan.Models do
     try do
       Kazan.Codegen.Naming.model_name_to_module(oai_name)
     rescue
-      CaseClauseError ->
+      Kazan.UnknownName ->
         nil
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,23 +2,23 @@ defmodule Kazan.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :kazan,
-     version: "0.10.0",
-     elixir: "~> 1.4",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps(),
+    [
+      app: :kazan,
+      version: "0.10.0",
+      elixir: "~> 1.4",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
 
-     # Hex.pm stuff
-     package: package(),
-     description: description(),
+      # Hex.pm stuff
+      package: package(),
+      description: description(),
 
-     # Docs
-     name: "Kazan",
-     source_url: "https://github.com/obmarg/kazan",
-     homepage_url: "https://github.com/obmarg/kazan",
-     docs: [main: "readme",
-            extras: ["README.md", "CHANGELOG.md"]]
+      # Docs
+      name: "Kazan",
+      source_url: "https://github.com/obmarg/kazan",
+      homepage_url: "https://github.com/obmarg/kazan",
+      docs: [main: "readme", extras: ["README.md", "CHANGELOG.md"]]
     ]
   end
 
@@ -39,26 +39,28 @@ defmodule Kazan.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:poison, "~> 2.0 or ~> 3.0 or ~> 4.0"},
-     {:httpoison, "~> 0.10 or ~> 1.0"},
-     {:yaml_elixir, "~> 2.0"},
+    [
+      {:poison, "~> 2.0 or ~> 3.0 or ~> 4.0"},
+      {:httpoison, "~> 0.10 or ~> 1.0"},
+      {:yaml_elixir, "~> 2.0"},
 
-     # Dev dependencies
-     {:ex_doc, "~> 0.14", only: :dev},
+      # Dev dependencies
+      {:ex_doc, "~> 0.14", only: :dev},
 
-     # Test dependencies
-     {:plug_cowboy, "~> 1.0", only: :test},
-     {:bypass, "~> 0.5", only: :test}
-   ]
+      # Test dependencies
+      {:plug_cowboy, "~> 1.0", only: :test},
+      {:bypass, "~> 0.5", only: :test}
+    ]
   end
 
   defp package do
-    [name: :kazan,
-     licenses: ["MIT"],
-     maintainers: ["Graeme Coupar"],
-     links: %{"GitHub" => "https://github.com/obmarg/kazan"},
-     files: ["lib", "priv", "mix.exs", "README*", "LICENSE*", "kube_specs"],
-   ]
+    [
+      name: :kazan,
+      licenses: ["MIT"],
+      maintainers: ["Graeme Coupar"],
+      links: %{"GitHub" => "https://github.com/obmarg/kazan"},
+      files: ["lib", "priv", "mix.exs", "README*", "LICENSE*", "kube_specs"]
+    ]
   end
 
   def description do

--- a/test/models_test.exs
+++ b/test/models_test.exs
@@ -197,10 +197,7 @@ defmodule KazanModelsTest do
 
   describe "Models.oai_name_to_module" do
     test "it returns a module for known models" do
-      model =
-        Kazan.Models.oai_name_to_module(
-          "io.k8s.api.core.v1.ComponentStatusList"
-        )
+      model = Kazan.Models.oai_name_to_module("io.k8s.api.core.v1.ComponentStatusList")
 
       assert model == Core.V1.ComponentStatusList
     end
@@ -208,8 +205,13 @@ defmodule KazanModelsTest do
     test "it returns nil for unknown models" do
       assert Kazan.Models.oai_name_to_module("someName") == nil
 
-      assert Kazan.Models.oai_name_to_module("io.k8s.api.core.v1.SomeName") ==
-               nil
+      assert Kazan.Models.oai_name_to_module("io.k8s.api.core.v1.SomeName") == nil
+    end
+
+    test "it supports names provided in app config" do
+      # Our config.exs defines this mapping, lets see if it works...
+      assert Kazan.Models.oai_name_to_module("something.test.whatever") ==
+               Kazan.Something.Whatever
     end
   end
 end


### PR DESCRIPTION
Some users of Kazan are using k8s extensions that add new APIs & models
to k8s.  Currently the only way to get Kazan to know about these new
APIs and models is to fork the library and update the swagger
appropriately.

This commit updates kazan with two new configuration options:

- `oai_spec` allows the user to provide a different open API spec file
  to compile the library with.
- `oai_name_mappings` allows the user to add extra mappings from open
api specification names to elixir modules.

Fixes #54