### PR TITLE
Fix bug inspecting DOWN reason in watcher

### DIFF
--- a/lib/kazan/watcher.ex
+++ b/lib/kazan/watcher.ex
@@ -232,7 +232,7 @@ defmodule Kazan.Watcher do
     log(
       state,
       "#{inspect(self())} - #{name} send_to process #{inspect(pid)} :DOWN reason: #{
-        reason
+        inspect(reason)
       }"
     )
 


### PR DESCRIPTION
If the parent fails due to a crash (which can be caused by the watcher crashing), then this makes the situation worse as the term cannot be logged.