### PR TITLE
implement basic auth when username and password are given

### DIFF
--- a/lib/kazan/client/imp.ex
+++ b/lib/kazan/client/imp.ex
@@ -40,6 +40,9 @@ defmodule Kazan.Client.Imp do
           %Server.ProviderAuth{token: token} when not is_nil(token) ->
             [{"Authorization", "Bearer #{token}"}]
 
+          %Server.BasicAuth{token: token} when not is_nil(token) ->
+            [{"Authorization", "Basic #{token}"}]
+
           %Server.ProviderAuth{} ->
             raise "Provider authentication needs resolved before use.  Please see Kazan.Server.resolve_auth/2 documentation for more details"
 

--- a/lib/kazan/server.ex
+++ b/lib/kazan/server.ex
@@ -7,6 +7,7 @@ defmodule Kazan.Server do
 
   @type auth_t ::
           nil
+          | Kazan.Server.BasicAuth.t()
           | Kazan.Server.CertificateAuth.t()
           | Kazan.Server.TokenAuth.t()
           | Kazan.Server.ProviderAuth.t()
@@ -307,6 +308,18 @@ defmodule Kazan.Server do
         token_key_path: json_path_to_key_list(token_key),
         expiry_key_path: json_path_to_key_list(expiry_key)
       }
+    }
+  end
+
+  defp auth_from_user(
+         %{
+           "username" => username,
+           "password" => password
+         },
+         _
+       ) do
+    %Kazan.Server.BasicAuth{
+      token: Base.encode64(username <> ":" <> password)
     }
   end
 

--- a/lib/kazan/server/basic_auth.ex
+++ b/lib/kazan/server/basic_auth.ex
@@ -1,0 +1,17 @@
+defmodule Kazan.Server.BasicAuth do
+  defstruct [:token]
+
+  @type t :: %__MODULE__{
+          token: binary
+        }
+
+  defimpl Inspect, for: __MODULE__ do
+    # We define a custom inspect implementation to avoid printing key details to
+    # logs or anything.
+    import Inspect.Algebra
+
+    def inspect(_auth, _opts) do
+      concat(["#BasicAuth<...>"])
+    end
+  end
+end


### PR DESCRIPTION
Im trying to get kazan working with k3s (https://k3s.io/) released by Rancher. After starting the k3s server, kube config looks like this

```
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: <<encoded-certificate-data>>
    server: https://localhost:6443
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: default
  user:
    password: randomized-password
    username: admin
```

None of the existing server auth methods support `username/password` authentication ie basic authentication strategy. This PR implements that. Tested with k3s and works fine!