### PR TITLE
Add support for decoding & encoding custom resources

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -12,6 +12,6 @@
 
   # Which local function calls (that is, calls without a module name) should not
   # be parenthesised.
-  locals_without_parens: [ ]
+  locals_without_parens: [property: 3, property: 4, defmodel: 4, defmodellist: 1]
 ]
 

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -12,6 +12,6 @@
 
   # Which local function calls (that is, calls without a module name) should not
   # be parenthesised.
-  locals_without_parens: [property: 3, property: 4, defmodel: 4, defmodellist: 1]
+  locals_without_parens: [property: 3, property: 4, defmodel: 4, defmodellist: 4]
 ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ all APIs might be changed.
 
 - We no longer require certificate-authority data for a server that's
   configured with `insecure-tls-verify: true` (#64)
+- Fixed the GKE section of the README, it referred to a function that didn't
+  actually exist.
 
 ## v0.11.0 - 2019-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,21 @@ all APIs might be changed.
 
 ## Unreleased - yyyy-mm-dd
 
+### Breaking Changes
+
+- The `Kazan.Codegen.Models.*` modules have been moved to `Kazan.Models.*`.
+  These were meant to be private previously, so hopefully this doesn't break
+  anything for people, but you never know.
+- `response_schema` on `Kazan.Request` has been renamed to `response_model`.
+
 ### New Features
 
 - Added an informational `server_info` field to Kazan.Server that can be used
   to check the names of the context, cluster & user that a Kazan.Server struct
   were initialised with.
+- Support for encoding & decoding custom resources.  This can be accomplished
+  by defining a module that implements the `Kazan.Model` behaviour.  See the
+  `Kazan.Model` documentation for more details.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,16 @@ all APIs might be changed.
 - `response_schema` on `Kazan.Request` has been renamed to `response_model`.
 - The models under `Kazan.Models.ApiextensionsApiServer` have been moved to
   `Kazan.Apis.Apiextensions` to live with their corresponding Api functions.
+- `Kazan.Models.PropertyDesc.type` is now an atom rather than a string.
 
 ### New Features
 
 - Added an informational `server_info` field to Kazan.Server that can be used
   to check the names of the context, cluster & user that a Kazan.Server struct
   were initialised with.
-- Support for encoding & decoding custom resources.  This can be accomplished
-  by defining a module that implements the `Kazan.Model` behaviour.  See the
-  `Kazan.Model` documentation for more details.
+- Kazan now supports custom resources.  These can easily be defined using the
+  macros in `Kazan.Model`, or you can manually implement the `Kazan.Model`
+  behaviour if you want to do serialization/deserilization yourself.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ all APIs might be changed.
   These were meant to be private previously, so hopefully this doesn't break
   anything for people, but you never know.
 - `response_schema` on `Kazan.Request` has been renamed to `response_model`.
+- The models under `Kazan.Models.ApiextensionsApiServer` have been moved to
+  `Kazan.Apis.Apiextensions` to live with their corresponding Api functions.
 
 ### New Features
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Looking for some help? Check out `kazan`'s Gitter [chatroom](https://gitter.im/k
 - Support for watch requests.
 - Typespecs for functions and structs (though dialyzer outputs a lot of
   warnings when run on Kazan)
-- Limited support for custom resources.
+- Limited support for custom resources.  See the `Kazan.Model` documentation
+  for more details.
 
 ### Not Implemented
 
@@ -110,8 +111,8 @@ this supports.
 
 If developing against GKE, gcloud can create a kube config file that Kazan can
 understand. However, in this case you will need to call
-`Kazan.Server.resolve_token/2` in order to query gcloud for a valid token. See
-the docs for `Kazan.Server.resolve_token` for more details.
+`Kazan.Server.resolve_auth/2` in order to query gcloud for a valid token. See
+the docs for `Kazan.Server.resolve_auth/2` for more details.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Looking for some help? Check out `kazan`'s Gitter [chatroom](https://gitter.im/k
 - Support for watch requests.
 - Typespecs for functions and structs (though dialyzer outputs a lot of
   warnings when run on Kazan)
+- Limited support for custom resources.
 
 ### Not Implemented
 
-- Custom resources (I'd be interested in supporting these, but it's not clear how to do it)
 - Other forms of authentication
 - Patching with `application/json-patch+json` or
   `application/strategic-merge-patch+json` content types.

--- a/config/config.exs
+++ b/config/config.exs
@@ -34,10 +34,7 @@ if Mix.env() == :test do
     oai_name_mappings: [{"something.test", Kazan.Something}]
 end
 
-
 if Mix.env() == :dev do
   config :kazan,
-  server: {:kubeconfig, System.user_home <> "/.kube/config"}
+    server: {:kubeconfig, System.user_home() <> "/.kube/config"}
 end
-
-

--- a/lib/kazan/apis.ex
+++ b/lib/kazan/apis.ex
@@ -44,7 +44,9 @@ defmodule Kazan.Apis do
 
       operation ->
         bang_function_name =
-          String.to_existing_atom(Atom.to_string(operation.function_name) <> "!")
+          String.to_existing_atom(
+            Atom.to_string(operation.function_name) <> "!"
+          )
 
         [
           {operation.api_module, operation.function_name},

--- a/lib/kazan/codegen/apis.ex
+++ b/lib/kazan/codegen/apis.ex
@@ -132,16 +132,19 @@ defmodule Kazan.Codegen.Apis do
   # Builds the quoted function form for an operation function.
   @spec function_form(Operation.t()) :: term
   defp function_form(operation) do
-    param_groups = Enum.group_by(operation.parameters, fn param -> param.type end)
+    param_groups =
+      Enum.group_by(operation.parameters, fn param -> param.type end)
 
     is_required = fn param -> param.required end
     query_params = Map.get(param_groups, :query, [])
 
-    path_params = param_groups |> Map.get(:path, []) |> sort_path_params(operation.path)
+    path_params =
+      param_groups |> Map.get(:path, []) |> sort_path_params(operation.path)
 
     # The main arguments our function will take:
     argument_params =
-      Map.get(param_groups, :body, []) ++ path_params ++ Enum.filter(query_params, is_required)
+      Map.get(param_groups, :body, []) ++
+        path_params ++ Enum.filter(query_params, is_required)
 
     optional_params = Enum.reject(query_params, is_required)
 
@@ -154,7 +157,7 @@ defmodule Kazan.Codegen.Apis do
         operation.description,
         argument_params,
         optional_params,
-        operation.response_schema
+        operation.response_model
       )
 
     param_unpacking =
@@ -196,7 +199,8 @@ defmodule Kazan.Codegen.Apis do
         {parameter.var_name, parameter.field_name}
       end
 
-    bang_function_name = String.to_atom(Atom.to_string(operation.function_name) <> "!")
+    bang_function_name =
+      String.to_atom(Atom.to_string(operation.function_name) <> "!")
 
     argument_forms_in_call =
       argument_call_forms(
@@ -222,9 +226,13 @@ defmodule Kazan.Codegen.Apis do
       end
 
       @doc unquote(docs)
-      @spec unquote(bang_function_name)(unquote_splicing(argument_specs)) :: Kazan.Request.t()
+      @spec unquote(bang_function_name)(unquote_splicing(argument_specs)) ::
+              Kazan.Request.t()
       def unquote(bang_function_name)(unquote_splicing(arguments)) do
-        rv = unquote(operation.function_name)(unquote_splicing(argument_forms_in_call))
+        rv =
+          unquote(operation.function_name)(
+            unquote_splicing(argument_forms_in_call)
+          )
 
         case rv do
           {:ok, result} ->
@@ -255,7 +263,8 @@ defmodule Kazan.Codegen.Apis do
   end
 
   defp argument_forms(argument_params, _optional_params) do
-    argument_forms(argument_params, []) ++ [{:\\, [], [Macro.var(:options, __MODULE__), []]}]
+    argument_forms(argument_params, []) ++
+      [{:\\, [], [Macro.var(:options, __MODULE__), []]}]
   end
 
   # List of argument specs to go in function spec.
@@ -267,7 +276,8 @@ defmodule Kazan.Codegen.Apis do
   end
 
   defp argument_spec_forms(argument_params, optional_params) do
-    argument_spec_forms(argument_params, []) ++ [optional_param_spec(optional_params)]
+    argument_spec_forms(argument_params, []) ++
+      [optional_param_spec(optional_params)]
   end
 
   # Generates a spec for an optional Keyword list.
@@ -355,14 +365,14 @@ defmodule Kazan.Codegen.Apis do
     <% end %>
     <% end %>
 
-    <%= if response_schema do %>
+    <%= if response_model do %>
     ### Response
 
-    See `<%= doc_ref(response_schema) %>`
+    See `<%= doc_ref(response_model) %>`
     <% end %>
 
     """,
-    [:operation_id, :description, :parameters, :options, :response_schema]
+    [:operation_id, :description, :parameters, :options, :response_model]
   )
 
   defp module_doc(api_id) do

--- a/lib/kazan/codegen/apis/operation.ex
+++ b/lib/kazan/codegen/apis/operation.ex
@@ -10,7 +10,7 @@ defmodule Kazan.Codegen.Apis.Operation do
     :api_id,
     :operation_id,
     :parameters,
-    :response_schema,
+    :response_model,
     :description,
     :path
   ]
@@ -21,7 +21,7 @@ defmodule Kazan.Codegen.Apis.Operation do
           api_id: ApiId.t(),
           operation_id: String.t(),
           parameters: list,
-          response_schema: struct,
+          response_model: struct,
           description: String.t(),
           path: String.t()
         }
@@ -48,7 +48,7 @@ defmodule Kazan.Codegen.Apis.Operation do
       api_id: api_id,
       operation_id: desc["operationId"],
       parameters: Enum.map(desc["parameters"], &Parameter.from_oai_desc/1),
-      response_schema:
+      response_model:
         Codegen.Naming.definition_ref_to_model_module(
           desc["responses"]["200"]["schema"]["$ref"]
         ),

--- a/lib/kazan/codegen/models.ex
+++ b/lib/kazan/codegen/models.ex
@@ -115,25 +115,25 @@ defmodule Kazan.Codegen.Models do
     [typespec_for_property(items)]
   end
 
-  defp typespec_for_property(%PropertyDesc{type: "string"}) do
+  defp typespec_for_property(%PropertyDesc{type: :string}) do
     quote do
       String.t()
     end
   end
 
-  defp typespec_for_property(%PropertyDesc{type: "integer"}) do
+  defp typespec_for_property(%PropertyDesc{type: :integer}) do
     {:integer, [], Elixir}
   end
 
-  defp typespec_for_property(%PropertyDesc{type: "number"}) do
+  defp typespec_for_property(%PropertyDesc{type: :number}) do
     {:float, [], Elixir}
   end
 
-  defp typespec_for_property(%PropertyDesc{type: "boolean"}) do
+  defp typespec_for_property(%PropertyDesc{type: :boolean}) do
     {:boolean, [], Elixir}
   end
 
-  defp typespec_for_property(%PropertyDesc{type: "object"}) do
+  defp typespec_for_property(%PropertyDesc{type: :object}) do
     {:map, [], Elixir}
   end
 
@@ -161,26 +161,26 @@ defmodule Kazan.Codegen.Models do
       "`#{doc_ref(property.ref)}`"
     else
       case property.type do
-        "array" ->
+        :array ->
           "[ #{property_type_doc(property.items)} ]"
 
-        "integer" ->
+        :integer ->
           "`Integer`"
 
-        "number" ->
+        :number ->
           "`Float`"
 
-        "object" ->
+        :object ->
           "`Map`"
 
-        "string" ->
+        :string ->
           case property.format do
             "date" -> "`Date`"
             "date-time" -> "`DateTime`"
             _ -> "`String`"
           end
 
-        "boolean" ->
+        :boolean ->
           "`Boolean`"
       end
     end

--- a/lib/kazan/codegen/models.ex
+++ b/lib/kazan/codegen/models.ex
@@ -3,9 +3,9 @@ defmodule Kazan.Codegen.Models do
   # Macros for generating client code from OAI specs.
   require EEx
 
-  require Kazan.Codegen.Models.ModelDesc
+  require Kazan.Models.ModelDesc
 
-  alias Kazan.Codegen.Models.{ModelDesc, PropertyDesc}
+  alias Kazan.Models.{ModelDesc, PropertyDesc}
   alias Kazan.Codegen.Naming
 
   @doc """
@@ -38,6 +38,11 @@ defmodule Kazan.Codegen.Models do
             defstruct unquote(property_names)
 
             @type t :: %__MODULE__{unquote_splicing(typespec)}
+
+            use Kazan.Model
+
+            @impl Kazan.Model
+            def model_desc(), do: unquote(Macro.escape(desc))
           end
         end
       end
@@ -46,11 +51,6 @@ defmodule Kazan.Codegen.Models do
       Module.put_attribute(__MODULE__, :external_resource, unquote(spec_file))
 
       unquote_splicing(spec_forms)
-
-      # Function returns a map of module name -> ModelDesc
-      defp model_descs do
-        unquote(Macro.escape(models))
-      end
 
       # Returns a map of ResourceId to module
       defp resource_id_index do

--- a/lib/kazan/codegen/naming.ex
+++ b/lib/kazan/codegen/naming.ex
@@ -40,7 +40,8 @@ defmodule Kazan.Codegen.Naming do
   # some common prefixes.
   # We also need to categorise things into API specific models or models that
   # live in the models module.
-  @spec module_name_components(String.t()) :: nonempty_improper_list(atom, String.t())
+  @spec module_name_components(String.t()) ::
+          nonempty_improper_list(atom, String.t())
   defp module_name_components(name) do
     to_components = fn str ->
       str |> String.split(".") |> Enum.map(&titlecase_once/1)
@@ -80,7 +81,8 @@ defmodule Kazan.Codegen.Naming do
             raise Kazan.UnknownName, name: other
 
           {oai_prefix, module_prefix} ->
-            [module_prefix] ++ to_components.(String.replace_leading(other, oai_prefix, ""))
+            [module_prefix] ++
+              to_components.(String.replace_leading(other, oai_prefix, ""))
         end
     end
   end

--- a/lib/kazan/codegen/naming.ex
+++ b/lib/kazan/codegen/naming.ex
@@ -68,8 +68,8 @@ defmodule Kazan.Codegen.Naming do
       "io.k8s.kube-aggregator.pkg.apis." <> rest ->
         [Kazan.Models.KubeAggregator] ++ to_components.(rest)
 
-      "io.k8s.apiextensions-apiserver.pkg.apis." <> rest ->
-        [Kazan.Models.ApiextensionsApiserver] ++ to_components.(rest)
+      "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions." <> rest ->
+        [Kazan.Apis.Apiextensions] ++ to_components.(rest)
 
       other ->
         Config.oai_name_mappings()

--- a/lib/kazan/model.ex
+++ b/lib/kazan/model.ex
@@ -1,0 +1,26 @@
+defmodule Kazan.Model do
+  @moduledoc """
+  Kazan.Model is a behaviour that provides encoding & decoding of JSON from a Kubernetes server.
+
+  This is used internally in Kazan for all it's generated models, however it can also be used to add custom resource definition support.
+
+  TODO: Add examples and docs
+  """
+  @callback decode(Map.t()) :: struct
+  @callback encode(struct) :: Map.t()
+  @callback model_desc() :: Kazan.ModelDesc.t()
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Kazan.Model
+
+      @impl Kazan.Model
+      def decode(data), do: Kazan.Models.decode(data, __MODULE__)
+
+      @impl Kazan.Model
+      def encode(data), do: Kazan.Models.encode(data)
+
+      defoverridable Kazan.Model
+    end
+  end
+end

--- a/lib/kazan/model.ex
+++ b/lib/kazan/model.ex
@@ -14,7 +14,8 @@ defmodule Kazan.Model do
 
   defmacro __using__(_opts) do
     quote do
-      import Kazan.Model, only: [defmodeldesc: 1, defmodellist: 1, defmodel: 1, property: 3]
+      import Kazan.Model,
+        only: [defmodellist: 4, defmodel: 4, property: 3, property: 4]
 
       @behaviour Kazan.Model
 
@@ -30,91 +31,71 @@ defmodule Kazan.Model do
 
   alias Kazan.Models.{ModelDesc, PropertyDesc}
 
-  @doc """
-  Builds a `Kazan.Models.ModelDesc` for a Model.
-
-  Use this to build the result of your Models `model_desc/0` function.
-  It reduces boilerplate by adding in the standard k8s API fields of
-  `metadata`, `api_version` & `kind`.
-  """
-  def build_model_desc(model, properties) do
-    %ModelDesc{
-      module_name: model,
-      properties:
-        Map.merge(
-          %{
-            metadata: %Kazan.Models.PropertyDesc{
-              field: "metadata",
-              type: nil,
-              ref: Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
-            },
-            kind: %Kazan.Models.PropertyDesc{field: "kind", type: "string"},
-            api_version: %Kazan.Models.PropertyDesc{
-              field: "apiVersion",
-              type: "string"
-            }
-          },
-          properties
-        )
-    }
-  end
-
-  defmacro property(local_name, remote_name, type) do
+  defmacro property(local_name, remote_name, type, default \\ nil) do
     quote do
-      @kazan_property_names unquote(local_name)
+      @kazan_property_names {unquote(local_name), unquote(default)}
       @kazan_property_remote_names unquote(remote_name)
       @kazan_property_types unquote(type)
     end
   end
 
-  # TODO: Possibly move the DSL stuff out into a DSL module?
+  defmacro defmodel(kind, group, version, block) do
+    prelude =
+      quote do
+        Module.register_attribute(__MODULE__, :kazan_property_names,
+          accumulate: true
+        )
 
-  # TODO: Need a compile hook that'll run before or after compile, read
-  # @_kazan_property and output the appropriate defstruct * defmodeldesc calls...
+        Module.register_attribute(__MODULE__, :kazan_property_remote_names,
+          accumulate: true
+        )
 
-  defmacro defmodel(block) do
-    prelude = quote do
-      Module.register_attribute(__MODULE__, :kazan_property_names, accumulate: true)
-      Module.register_attribute(__MODULE__, :kazan_properties, accumulate: true)
+        Module.register_attribute(__MODULE__, :kazan_property_types,
+          accumulate: true
+        )
 
-      property :metadata, "a_string", Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
-      property :api_version, "apiVersion", "string"
-      property :kind, "kind", "string"
+        property :metadata,
+                 "metadata",
+                 Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
 
-      unquote(block)
-    end
+        group_version = "#{unquote(group)}/#{unquote(version)}"
 
-    postlude = quote unquote: false do
-      property_names = @kazan_property_names |> Enum.reverse
-      property_remote_names = @kazan_property_names |> Enum.reverse
-      property_remote_types = @kazan_property_names |> Enum.reverse
+        property :api_version, "apiVersion", :string, group_version
+        property :kind, "kind", :string, unquote(kind)
 
-      defstruct @kazan_property_names
+        unquote(block)
+      end
 
-      # TODO: Generate a model_desc function as well...
-    end
+    postlude =
+      quote unquote: false do
+        property_names = @kazan_property_names |> Enum.reverse()
+        property_remote_names = @kazan_property_remote_names |> Enum.reverse()
+        property_remote_types = @kazan_property_types |> Enum.reverse()
+
+        @properties Enum.zip([
+                      property_names,
+                      property_remote_names,
+                      property_remote_types
+                    ])
+                    |> Enum.map(fn {{name, _default}, remote_name, type} ->
+                      {name, %PropertyDesc{field: remote_name, type: type}}
+                    end)
+                    |> Enum.into(%{})
+
+        defstruct @kazan_property_names
+
+        @impl Kazan.Model
+        def model_desc() do
+          %Kazan.Models.ModelDesc{
+            module_name: __MODULE__,
+            properties: @properties
+          }
+        end
+      end
 
     quote do
       unquote(prelude)
       unquote(postlude)
-    end
-  end
-
-  defmacro __before_compile_model__(_env) do
-    quote do
-      @_kazan_property_names Enum.map(@_kazan_property, fn {name, _, _} -> name end)
-
-      defmodel @_kazan_property_names
-    end
-  end
-
-  # TODO: Document
-  defmacro defmodeldesc(properties) do
-    quote do
-      @impl Kazan.Model
-      def model_desc() do
-        Kazan.Model.build_model_desc(__MODULE__, unquote(properties))
-      end
     end
   end
 
@@ -132,23 +113,10 @@ defmodule Kazan.Model do
         Kazan.Model.list_of(Pod)
       end
   """
-  defmacro defmodellist(item_model) do
+  defmacro defmodellist(kind, group, version, item_model) do
     quote do
-      defstruct [:items, :metadata, :kind, :api_version]
-
-      @impl Kazan.Model
-      def model_desc() do
-        alias Kazan.Models.{ModelDesc, PropertyDesc}
-
-        alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
-
-        Kazan.Model.build_model_desc(__MODULE__, %{
-          items: %PropertyDesc{
-            field: "items",
-            type: "array",
-            items: %PropertyDesc{type: nil, ref: unquote(item_model)}
-          }
-        })
+      defmodel unquote(kind), unquote(group), unquote(version) do
+        property :items, "items", {:array, unquote(item_model)}
       end
     end
   end

--- a/lib/kazan/model.ex
+++ b/lib/kazan/model.ex
@@ -43,13 +43,13 @@ defmodule Kazan.Model do
   defmacro list_of(item_model) do
 
     quote do
-      alias Kazan.Models.{ModelDesc, PropertyDesc}
-
-      alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
-
       defstruct [:items, :metadata, :kind, :api_version]
 
       def model_desc() do
+        alias Kazan.Models.{ModelDesc, PropertyDesc}
+
+        alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
+
         %ModelDesc{
           module_name: __MODULE__,
           properties: %{

--- a/lib/kazan/models.ex
+++ b/lib/kazan/models.ex
@@ -167,6 +167,10 @@ defmodule Kazan.Models do
     map_ok(value, &encode_property(&1, items))
   end
 
+  defp encode_property(value, %{type: nil, ref: model}) do
+    model.encode(value)
+  end
+
   defp encode_property(value, %{type: nil}) do
     encode(value)
   end

--- a/lib/kazan/models/model_desc.ex
+++ b/lib/kazan/models/model_desc.ex
@@ -3,8 +3,6 @@ defmodule Kazan.Models.ModelDesc do
   import Kazan.Codegen.Naming, only: [model_name_to_module: 1]
   alias Kazan.Models.{ResourceId, PropertyDesc}
 
-  # TODO: document it.
-
   defstruct [
     :id,
     :resource_ids,

--- a/lib/kazan/models/model_desc.ex
+++ b/lib/kazan/models/model_desc.ex
@@ -1,7 +1,9 @@
-defmodule Kazan.Codegen.Models.ModelDesc do
+defmodule Kazan.Models.ModelDesc do
   @moduledoc false
   import Kazan.Codegen.Naming, only: [model_name_to_module: 1]
-  alias Kazan.Codegen.Models.{ResourceId, PropertyDesc}
+  alias Kazan.Models.{ResourceId, PropertyDesc}
+
+  # TODO: document it.
 
   defstruct [
     :id,

--- a/lib/kazan/models/property_desc.ex
+++ b/lib/kazan/models/property_desc.ex
@@ -1,6 +1,8 @@
-defmodule Kazan.Codegen.Models.PropertyDesc do
+defmodule Kazan.Models.PropertyDesc do
   @moduledoc false
   import Kazan.Codegen.Naming, only: [definition_ref_to_model_module: 1]
+
+  # TODO: document
 
   defstruct [:type, :format, :description, :ref, :field, :items]
 

--- a/lib/kazan/models/property_desc.ex
+++ b/lib/kazan/models/property_desc.ex
@@ -2,8 +2,6 @@ defmodule Kazan.Models.PropertyDesc do
   @moduledoc false
   import Kazan.Codegen.Naming, only: [definition_ref_to_model_module: 1]
 
-  # TODO: document
-
   defstruct [:type, :format, :description, :ref, :field, :items]
 
   @type t :: %{

--- a/lib/kazan/models/property_desc.ex
+++ b/lib/kazan/models/property_desc.ex
@@ -7,7 +7,7 @@ defmodule Kazan.Models.PropertyDesc do
   defstruct [:type, :format, :description, :ref, :field, :items]
 
   @type t :: %{
-          :type => String.t() | nil,
+          :type => atom | nil,
           :format => String.t() | nil,
           :description => String.t() | nil,
           :ref => atom | nil,
@@ -39,7 +39,7 @@ defmodule Kazan.Models.PropertyDesc do
       end
 
     %__MODULE__{
-      type: map["type"],
+      type: parse_type(map["type"]),
       format: map["format"],
       description: map["description"],
       field: field,
@@ -50,4 +50,12 @@ defmodule Kazan.Models.PropertyDesc do
 
   defp parse_items(nil, _), do: nil
   defp parse_items(map, refs), do: from_oai_desc(map, nil, refs)
+
+  defp parse_type(nil), do: nil
+  defp parse_type("string"), do: :string
+  defp parse_type("boolean"), do: :boolean
+  defp parse_type("integer"), do: :integer
+  defp parse_type("number"), do: :number
+  defp parse_type("object"), do: :object
+  defp parse_type("array"), do: :array
 end

--- a/lib/kazan/models/resource_id.ex
+++ b/lib/kazan/models/resource_id.ex
@@ -1,4 +1,4 @@
-defmodule Kazan.Codegen.Models.ResourceId do
+defmodule Kazan.Models.ResourceId do
   @moduledoc false
   # Stores the kind, version & group of a kubernetes resource.
 

--- a/lib/kazan/server.ex
+++ b/lib/kazan/server.ex
@@ -32,7 +32,7 @@ defmodule Kazan.Server do
           insecure_skip_tls_verify: Boolean.t(),
           ca_cert: String.t() | nil,
           auth: auth_t,
-          server_info: Kazan.Server.ServerInfo.t | nil
+          server_info: Kazan.Server.ServerInfo.t() | nil
         }
 
   @doc """

--- a/lib/kazan/server.ex
+++ b/lib/kazan/server.ex
@@ -146,7 +146,10 @@ defmodule Kazan.Server do
   Creates a `Kazan.Server` from some user provided application config.
   """
   def from_env({:kubeconfig, file}), do: Server.from_kubeconfig(file)
-  def from_env({:kubeconfig, file, opts}), do: Server.from_kubeconfig(file, opts)
+
+  def from_env({:kubeconfig, file, opts}),
+    do: Server.from_kubeconfig(file, opts)
+
   def from_env(:in_cluster), do: Server.in_cluster()
   def from_env(map = %{}), do: Server.from_map(map)
 
@@ -209,7 +212,8 @@ defmodule Kazan.Server do
     # This clause handles the case where we've already got a token.
     # Will only refresh if we're forcing, or the token has expired.
     should_resolve =
-      Keyword.get(opts, :force) || DateTime.compare(auth.expiry, DateTime.utc_now()) != :gt
+      Keyword.get(opts, :force) ||
+        DateTime.compare(auth.expiry, DateTime.utc_now()) != :gt
 
     if should_resolve do
       resolve_auth(%{server | auth: %{auth | token: nil}}, opts)
@@ -239,9 +243,11 @@ defmodule Kazan.Server do
 
   # Fetches authorization from the configured auth provider.
   defp fetch_auth_from_provider(%ProviderAuth{} = auth) do
-    with {cmd_response, 0} <- System.cmd(auth.config.cmd_path, auth.config.cmd_args),
+    with {cmd_response, 0} <-
+           System.cmd(auth.config.cmd_path, auth.config.cmd_args),
          {:ok, data} <- Poison.decode(cmd_response),
-         token when not is_nil(token) <- get_in(data, auth.config.token_key_path),
+         token when not is_nil(token) <-
+           get_in(data, auth.config.token_key_path),
          {:ok, expiry, _} <-
            data
            |> get_in(auth.config.expiry_key_path)

--- a/lib/kazan/server/server_info.ex
+++ b/lib/kazan/server/server_info.ex
@@ -4,5 +4,9 @@ defmodule Kazan.Server.ServerInfo do
   """
   defstruct [:context_name, :user_name, :cluster_name]
 
-  @type t :: %__MODULE__{context_name: String.t, user_name: String.t, cluster_name: String.t}
+  @type t :: %__MODULE__{
+          context_name: String.t(),
+          user_name: String.t(),
+          cluster_name: String.t()
+        }
 end

--- a/lib/kazan/watcher.ex
+++ b/lib/kazan/watcher.ex
@@ -276,12 +276,11 @@ defmodule Kazan.Watcher do
   defp process_line(line, current_rv, %State{} = state) do
     %State{
       name: name,
-      send_to: send_to,
-      request: %Kazan.Request{response_model: response_model}
+      send_to: send_to
     } = state
 
     {:ok, %{"type" => type, "object" => raw_object}} = Poison.decode(line)
-    {:ok, model} = decode(raw_object, response_model)
+    {:ok, model} = Kazan.Models.decode(raw_object, nil)
 
     case extract_rv(raw_object) do
       {:gone, message} ->
@@ -329,10 +328,4 @@ defmodule Kazan.Watcher do
   defp log(log_level, msg) do
     Logger.log(log_level, fn -> msg end)
   end
-
-  # Decode helpers: if we know what model we're expecting, use that.
-  # Otherwise defer to Kazan.Models.decode which will try to guess the model
-  # from the kind provided in the response.
-  defp decode(data, nil), do: Kazan.Models.decode(data, nil)
-  defp decode(data, response_model), do: response_model.decode(data)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Kazan.Mixfile do
       app: :kazan,
       version: "0.11.0",
       elixir: "~> 1.4",
+      elixirc_paths: elixirc_paths(Mix.env),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -28,6 +29,10 @@ defmodule Kazan.Mixfile do
   def application do
     [applications: [:logger, :httpoison, :poison, :yaml_elixir]]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   # Dependencies can be Hex packages:
   #

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -253,18 +253,16 @@ defmodule KazanIntegrationTest do
       }
       |> Kazan.run!(server: server)
 
-      foo =
+      %FooResourceList{items: [foo]} =
         %Kazan.Request{
           method: "get",
-          path: "/apis/example.com/v1/namespaces/#{@namespace}/foos/test-foo",
+          path: "/apis/example.com/v1/namespaces/#{@namespace}/foos",
           query_params: %{},
           content_type: "application/json",
           body: nil,
-          response_model: FooResource
+          response_model: FooResourceList
         }
         |> Kazan.run!(server: server)
-
-      # TODO: getting things as a list?
 
       assert foo.a_string == "test"
       assert foo.an_int == 1

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -195,6 +195,82 @@ defmodule KazanIntegrationTest do
     assert log_lines == "hello\n"
   end
 
+  describe "Custom Resources" do
+    alias Kazan.Apis.Apiextensions.V1beta1, as: Apiextensions
+
+    alias Apiextensions.{
+      CustomResourceDefinition,
+      CustomResourceDefinitionSpec,
+      CustomResourceDefinitionNames
+    }
+
+    setup %{server: server} do
+      Apiextensions.create_custom_resource_definition!(
+        %CustomResourceDefinition{
+          metadata: %ObjectMeta{name: "foos.example.com"},
+          spec: %CustomResourceDefinitionSpec{
+            group: "example.com",
+            version: "v1",
+            scope: "Namespaced",
+            names: %CustomResourceDefinitionNames{
+              plural: "foos",
+              kind: "Foo"
+            }
+          }
+        }
+      )
+      |> Kazan.run!(server: server)
+
+      # Wait for the CRD to be created
+      Process.sleep(500)
+
+      on_exit(fn ->
+        Apiextensions.delete_custom_resource_definition!(
+          %DeleteOptions{},
+          "foos.example.com"
+        )
+        |> Kazan.run!(server: server)
+      end)
+    end
+
+    test "can create & query custom resources", %{server: server} do
+      {:ok, body} =
+        FooResource.encode(%FooResource{
+          a_string: "test",
+          an_int: 1,
+          metadata: %ObjectMeta{name: "test-foo", namespace: @namespace},
+          kind: "Foo",
+          api_version: "example.com/v1"
+        })
+
+      %Kazan.Request{
+        method: "post",
+        path: "/apis/example.com/v1/namespaces/#{@namespace}/foos",
+        query_params: %{},
+        content_type: "application/json",
+        body: Poison.encode!(body),
+        response_model: FooResource
+      }
+      |> Kazan.run!(server: server)
+
+      foo =
+        %Kazan.Request{
+          method: "get",
+          path: "/apis/example.com/v1/namespaces/#{@namespace}/foos/test-foo",
+          query_params: %{},
+          content_type: "application/json",
+          body: nil,
+          response_model: FooResource
+        }
+        |> Kazan.run!(server: server)
+
+      # TODO: getting things as a list?
+
+      assert foo.a_string == "test"
+      assert foo.an_int == 1
+    end
+  end
+
   defp wait_for_pod_to_run(_pod_name, 0, _) do
     flunk("Timed out waiting for pod to start")
   end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -238,9 +238,7 @@ defmodule KazanIntegrationTest do
         FooResource.encode(%FooResource{
           a_string: "test",
           an_int: 1,
-          metadata: %ObjectMeta{name: "test-foo", namespace: @namespace},
-          kind: "Foo",
-          api_version: "example.com/v1"
+          metadata: %ObjectMeta{name: "test-foo", namespace: @namespace}
         })
 
       %Kazan.Request{

--- a/test/model_test.exs
+++ b/test/model_test.exs
@@ -1,0 +1,39 @@
+defmodule KazanModelTest do
+  use ExUnit.Case, async: true
+
+  alias Kazan.Models.Apimachinery.Meta.V1.{
+    ObjectMeta
+  }
+
+  test "can encode a custom resource defined via defmodel" do
+    assert FooResource.encode(%FooResource{
+             an_int: 100,
+             a_string: "hello",
+             metadata: %ObjectMeta{name: "test-foo", namespace: "default"}
+           }) ==
+             {:ok,
+              %{
+                "a_string" => "hello",
+                "an_int" => 100,
+                "apiVersion" => "example.com/v1",
+                "kind" => "Foo",
+                "metadata" => %{"name" => "test-foo", "namespace" => "default"}
+              }}
+  end
+
+  test "can decode a custom resource defined via defmodel" do
+    assert FooResource.decode(%{
+             "a_string" => "hello",
+             "an_int" => 100,
+             "apiVersion" => "example.com/v1",
+             "kind" => "Foo",
+             "metadata" => %{"name" => "test-foo", "namespace" => "default"}
+           }) ==
+             {:ok,
+              %FooResource{
+                an_int: 100,
+                a_string: "hello",
+                metadata: %ObjectMeta{name: "test-foo", namespace: "default"}
+              }}
+  end
+end

--- a/test/models_test.exs
+++ b/test/models_test.exs
@@ -197,7 +197,10 @@ defmodule KazanModelsTest do
 
   describe "Models.oai_name_to_module" do
     test "it returns a module for known models" do
-      model = Kazan.Models.oai_name_to_module("io.k8s.api.core.v1.ComponentStatusList")
+      model =
+        Kazan.Models.oai_name_to_module(
+          "io.k8s.api.core.v1.ComponentStatusList"
+        )
 
       assert model == Core.V1.ComponentStatusList
     end
@@ -205,7 +208,8 @@ defmodule KazanModelsTest do
     test "it returns nil for unknown models" do
       assert Kazan.Models.oai_name_to_module("someName") == nil
 
-      assert Kazan.Models.oai_name_to_module("io.k8s.api.core.v1.SomeName") == nil
+      assert Kazan.Models.oai_name_to_module("io.k8s.api.core.v1.SomeName") ==
+               nil
     end
 
     test "it supports names provided in app config" do

--- a/test/support/fooresource.ex
+++ b/test/support/fooresource.ex
@@ -4,7 +4,10 @@ defmodule FooResource do
 
   alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
 
-  defmodel([:a_string, :an_int])
+  defmodel do
+    property :a_string, "a_string", :string
+    property :an_int, "an_int", :int
+  end
 
   defmodeldesc(%{
     a_string: %PropertyDesc{field: "a_string", type: "string"},

--- a/test/support/fooresource.ex
+++ b/test/support/fooresource.ex
@@ -19,3 +19,28 @@ defmodule FooResource do
     }
   end
 end
+
+defmodule FooResourceList do
+  use Kazan.Model
+  alias Kazan.Models.{ModelDesc, PropertyDesc}
+
+  alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
+
+  defstruct [:items, :metadata, :kind, :api_version]
+
+  def model_desc() do
+    %ModelDesc{
+      module_name: __MODULE__,
+      properties: %{
+        metadata: %PropertyDesc{field: "metadata", type: nil, ref: ObjectMeta},
+        kind: %PropertyDesc{field: "kind", type: "string"},
+        api_version: %PropertyDesc{field: "apiVersion", type: "string"},
+        items: %PropertyDesc{
+          field: "items",
+          type: "array",
+          items: %PropertyDesc{type: nil, ref: FooResource}
+        }
+      }
+    }
+  end
+end

--- a/test/support/fooresource.ex
+++ b/test/support/fooresource.ex
@@ -4,23 +4,17 @@ defmodule FooResource do
 
   alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
 
-  defstruct [:a_string, :an_int, :metadata, :kind, :api_version]
+  defmodel([:a_string, :an_int])
 
-  def model_desc() do
-    %ModelDesc{
-      module_name: __MODULE__,
-      properties: %{
-        metadata: %PropertyDesc{field: "metadata", type: nil, ref: ObjectMeta},
-        kind: %PropertyDesc{field: "kind", type: "string"},
-        api_version: %PropertyDesc{field: "apiVersion", type: "string"}
-        a_string: %PropertyDesc{field: "a_string", type: "string"},
-        an_int: %PropertyDesc{field: "an_int", type: "integer"},
-      }
-    }
-  end
+  defmodeldesc(%{
+    a_string: %PropertyDesc{field: "a_string", type: "string"},
+    an_int: %PropertyDesc{field: "an_int", type: "integer"}
+  })
 end
 
 defmodule FooResourceList do
   use Kazan.Model
-  Kazan.Model.list_of(Foo)
+
+  # TODO: Add formatter rule for this Guy
+  defmodellist(FooResource)
 end

--- a/test/support/fooresource.ex
+++ b/test/support/fooresource.ex
@@ -1,0 +1,21 @@
+defmodule FooResource do
+  use Kazan.Model
+  alias Kazan.Models.{ModelDesc, PropertyDesc}
+
+  alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
+
+  defstruct [:a_string, :an_int, :metadata, :kind, :api_version]
+
+  def model_desc() do
+    %ModelDesc{
+      module_name: __MODULE__,
+      properties: %{
+        metadata: %PropertyDesc{field: "metadata", type: nil, ref: ObjectMeta},
+        kind: %PropertyDesc{field: "kind", type: "string"},
+        a_string: %PropertyDesc{field: "a_string", type: "string"},
+        an_int: %PropertyDesc{field: "an_int", type: "integer"},
+        api_version: %PropertyDesc{field: "apiVersion", type: "string"}
+      }
+    }
+  end
+end

--- a/test/support/fooresource.ex
+++ b/test/support/fooresource.ex
@@ -1,23 +1,14 @@
 defmodule FooResource do
   use Kazan.Model
-  alias Kazan.Models.{ModelDesc, PropertyDesc}
 
-  alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
-
-  defmodel do
+  defmodel "Foo", "example.com", "v1" do
     property :a_string, "a_string", :string
-    property :an_int, "an_int", :int
+    property :an_int, "an_int", :integer
   end
-
-  defmodeldesc(%{
-    a_string: %PropertyDesc{field: "a_string", type: "string"},
-    an_int: %PropertyDesc{field: "an_int", type: "integer"}
-  })
 end
 
 defmodule FooResourceList do
   use Kazan.Model
 
-  # TODO: Add formatter rule for this Guy
-  defmodellist(FooResource)
+  defmodellist "FooList", "example.com", "v1", FooResource
 end

--- a/test/support/fooresource.ex
+++ b/test/support/fooresource.ex
@@ -12,9 +12,9 @@ defmodule FooResource do
       properties: %{
         metadata: %PropertyDesc{field: "metadata", type: nil, ref: ObjectMeta},
         kind: %PropertyDesc{field: "kind", type: "string"},
+        api_version: %PropertyDesc{field: "apiVersion", type: "string"}
         a_string: %PropertyDesc{field: "a_string", type: "string"},
         an_int: %PropertyDesc{field: "an_int", type: "integer"},
-        api_version: %PropertyDesc{field: "apiVersion", type: "string"}
       }
     }
   end
@@ -22,25 +22,5 @@ end
 
 defmodule FooResourceList do
   use Kazan.Model
-  alias Kazan.Models.{ModelDesc, PropertyDesc}
-
-  alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
-
-  defstruct [:items, :metadata, :kind, :api_version]
-
-  def model_desc() do
-    %ModelDesc{
-      module_name: __MODULE__,
-      properties: %{
-        metadata: %PropertyDesc{field: "metadata", type: nil, ref: ObjectMeta},
-        kind: %PropertyDesc{field: "kind", type: "string"},
-        api_version: %PropertyDesc{field: "apiVersion", type: "string"},
-        items: %PropertyDesc{
-          field: "items",
-          type: "array",
-          items: %PropertyDesc{type: nil, ref: FooResource}
-        }
-      }
-    }
-  end
+  Kazan.Model.list_of(Foo)
 end


### PR DESCRIPTION
This updates Kazan with support for custom resources.  See the `Kazan.Model` documentation for more details.

Fixes #59 