### PR TITLE
Fix typespecs for optional model fields

### DIFF
--- a/lib/kazan/codegen/models.ex
+++ b/lib/kazan/codegen/models.ex
@@ -98,8 +98,18 @@ defmodule Kazan.Codegen.Models do
   # Generates a typespec map for a model
   defp typespec_for_model(%ModelDesc{} = model_desc) do
     for {name, desc} <- model_desc.properties do
-      {name, typespec_for_property(desc)}
+      {name,
+       desc
+       |> typespec_for_property()
+       |> typespec_optional(name not in model_desc.required)}
     end
+  end
+
+  @spec typespec_optional([{atom, term}], boolean()) :: [{atom, term}]
+  defp typespec_optional(typespec_ast, false), do: typespec_ast
+
+  defp typespec_optional(typespec_ast, true) do
+    {:|, [], [typespec_ast, nil]}
   end
 
   @spec typespec_for_property(PropertyDesc.t()) :: [{atom, term}]


### PR DESCRIPTION
When generating the typespecs for models, the `required` field in the swagger definition is ignored, leading to dialyzer errors when instantiating a model struct without specifying all fields.

The AST previously created a typespec for a struct field like
```
my_field: my_type
``` 
but this PR now creates it as follows if the field is not required:
```
my_field: my_type | nil
``` 
