### PR TITLE
Remove :ssl warning log by specifying the :verify option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ all APIs might be changed.
   actually exist.
 - Watcher now handles `410 Expired` messages in the same way as `410 Gone`,
   prior to this it would crash when these were received.
+- We now specify `[verify: :verify_peer]` when the `cacerts` SSL option is
+  specified; this removes the warning log from `:ssl`.
 
 ## v0.11.0 - 2019-03-26
 

--- a/lib/kazan/client/imp.ex
+++ b/lib/kazan/client/imp.ex
@@ -171,7 +171,7 @@ defmodule Kazan.Client.Imp do
     ca_options =
       case server.ca_cert do
         nil -> []
-        cert -> [cacerts: [cert]]
+        cert -> [cacerts: [cert], verify: :verify_peer]
       end
 
     auth_options ++ verify_options ++ ca_options


### PR DESCRIPTION
We now specify `[verify: :verify_peer]` when the `cacerts` SSL option is specified; this removes the warning log from `:ssl`.