### PR TITLE
Make backwards compatible with elixir 1.14.1

### DIFF
--- a/lib/kazan/server/basic_auth.ex
+++ b/lib/kazan/server/basic_auth.ex
@@ -5,7 +5,7 @@ defmodule Kazan.Server.BasicAuth do
           token: binary
         }
 
-  defimpl Inspect, for: __MODULE__ do
+  defimpl Inspect do
     # We define a custom inspect implementation to avoid printing key details to
     # logs or anything.
     import Inspect.Algebra

--- a/lib/kazan/server/certificate_auth.ex
+++ b/lib/kazan/server/certificate_auth.ex
@@ -6,7 +6,7 @@ defmodule Kazan.Server.CertificateAuth do
           key: binary
         }
 
-  defimpl Inspect, for: __MODULE__ do
+  defimpl Inspect do
     # We define a custom inspect implementation to avoid printing key details to
     # logs or anything.
     import Inspect.Algebra


### PR DESCRIPTION
Remove `for: __MODULE__` to remain backwards compatible with Elixir 1.14.1

https://github.com/obmarg/kazan/issues/81