### PR TITLE
Fix typos

### DIFF
--- a/lib/kazan/codegen/apis.ex
+++ b/lib/kazan/codegen/apis.ex
@@ -311,7 +311,7 @@ defmodule Kazan.Codegen.Apis do
     end
   end
 
-  # List of arugment forms to go in call to function from bang function.
+  # List of argument forms to go in call to function from bang function.
   @spec argument_call_forms([Map.t()], [Map.t()]) :: [term]
   defp argument_call_forms(argument_params, []) do
     for param <- argument_params do
@@ -381,7 +381,7 @@ defmodule Kazan.Codegen.Apis do
         """
         Module for the #{group} API group.
 
-        This module contains functions that can be used to query the avaliable
+        This module contains functions that can be used to query the available
         versions of the #{group} API in a k8s server. Each of these functions
         will output a `Kazan.Request` suitable for passing to `Kazan.run`.
 

--- a/lib/kazan/model.ex
+++ b/lib/kazan/model.ex
@@ -180,9 +180,9 @@ defmodule Kazan.Model do
   end
 
   @doc """
-  Utility macro for definining lists of custom resources.
+  Utility macro for defining lists of custom resources.
 
-  This generates all the neccesary boilerplate for a `Kazan.Model` that
+  This generates all the necessary boilerplate for a `Kazan.Model` that
   represents a k8s list containing `item_model`.
 
   For example, if you needed to recreate a PodList that contains Pods:

--- a/lib/kazan/server.ex
+++ b/lib/kazan/server.ex
@@ -99,7 +99,7 @@ defmodule Kazan.Server do
   end
 
   # Server.from_map can be used to convert a map into a Server.t. Useful when
-  # working with mix config, where the kazan structs are unavaliable.
+  # working with mix config, where the kazan structs are unavailable.
   @doc false
   @spec from_map(Server.t() | Map.t()) :: Server.t()
   def from_map(%Server{} = server), do: server


### PR DESCRIPTION
Found via `codespell -S deps,kube_specs -L ot`